### PR TITLE
xgameprotocol: add stubs

### DIFF
--- a/dlls/xgameruntime/GDKComponent/System/XGameProtocol.c
+++ b/dlls/xgameruntime/GDKComponent/System/XGameProtocol.c
@@ -1,0 +1,98 @@
+/*
+ * Xbox Game runtime Library
+ *  GDK Component: System API -> XGameProtocol
+ *
+ * Written by LukasPAH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "XGameProtocol.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
+
+static inline struct x_gameprotocol *impl_from_IXGameProtocolImpl(IXGameProtocolImpl *iface)
+{
+    return CONTAINING_RECORD(iface, struct x_gameprotocol, IXGameProtocolImpl_iface);
+}
+
+static HRESULT WINAPI x_gameprotocol_QueryInterface(IXGameProtocolImpl *iface, REFIID iid, void **out)
+{
+    struct x_gameprotocol *impl = impl_from_IXGameProtocolImpl(iface);
+
+    TRACE("iface %p, iid %s, out %p.\n", iface, debugstr_guid(iid), out);
+
+    if (IsEqualGUID(iid, &IID_IUnknown) || IsEqualGUID(iid, &IID_IXGameProtocolImpl))
+    {
+        *out = &impl->IXGameProtocolImpl_iface;
+        impl->IXGameProtocolImpl_iface.lpVtbl->AddRef(*out);
+        return S_OK;
+    }
+
+    FIXME("%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid(iid));
+    *out = NULL;
+    return E_NOINTERFACE;
+}
+
+static ULONG WINAPI x_gameprotocol_AddRef(IXGameProtocolImpl *iface)
+{
+    struct x_gameprotocol *impl = impl_from_IXGameProtocolImpl(iface);
+    ULONG ref = InterlockedIncrement(&impl->ref);
+    TRACE("iface %p increasing refcount to %lu.\n", iface, ref);
+    return ref;
+}
+
+static ULONG WINAPI x_gameprotocol_Release(IXGameProtocolImpl *iface)
+{
+    struct x_gameprotocol *impl = impl_from_IXGameProtocolImpl(iface);
+    ULONG ref = InterlockedDecrement(&impl->ref);
+    TRACE("iface %p decreasing refcount to %lu.\n", iface, ref);
+    return ref;
+}
+
+static HRESULT WINAPI x_gameprotocol_XGameProtocolRegisterForActivation(IXGameProtocolImpl *iface, XTaskQueueHandle queue, void *context, void *callback, XTaskQueueRegistrationToken *token)
+{
+    FIXME("iface %p, queue %p, context %p, callback %p, token %p stub!\n", iface, queue, context, callback, token);
+    return S_OK;
+}
+
+static void WINAPI x_gameprotocol_XGameProtocolActivationCallback(IXGameProtocolImpl *iface, void *context, const LPSTR protocolUri)
+{
+    FIXME("iface %p, context %p, protocolUri %p stub!\n", iface, context, protocolUri);
+}
+
+static BOOLEAN WINAPI x_gameprotocol_XGameProtocolUnregisterForActivation(IXGameProtocolImpl *iface, XTaskQueueRegistrationToken *token, boolean wait)
+{
+    FIXME("iface %p, token %p, wait %d stub!\n", iface, token, wait);
+    return TRUE;
+}
+
+static const struct IXGameProtocolImplVtbl x_gameprotocol_vtbl =
+    {
+        x_gameprotocol_QueryInterface,
+        x_gameprotocol_AddRef,
+        x_gameprotocol_Release,
+        /* IXGameProtocolImpl methods */
+        x_gameprotocol_XGameProtocolRegisterForActivation,
+        x_gameprotocol_XGameProtocolUnregisterForActivation,
+        x_gameprotocol_XGameProtocolActivationCallback,
+};
+
+static struct x_gameprotocol x_gameprotocol =
+    {
+        {&x_gameprotocol_vtbl},
+        0};
+
+IXGameProtocolImpl *x_gameprotocol_impl = &x_gameprotocol.IXGameProtocolImpl_iface;

--- a/dlls/xgameruntime/GDKComponent/System/XGameProtocol.h
+++ b/dlls/xgameruntime/GDKComponent/System/XGameProtocol.h
@@ -1,0 +1,35 @@
+/*
+ * Xbox Game runtime Library
+ *  GDK Component: System API -> XGameProtocol
+ *
+ * Written by LukasPAH
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef XGAMEPROTOCOL_H
+#define XGAMEPROTOCOL_H
+
+#include "../../private.h"
+
+#include <string.h>
+
+struct x_gameprotocol
+{
+    IXGameProtocolImpl IXGameProtocolImpl_iface;
+    LONG ref;
+};
+
+#endif

--- a/dlls/xgameruntime/Makefile.in
+++ b/dlls/xgameruntime/Makefile.in
@@ -17,5 +17,6 @@ SOURCES = \
 	GDKComponent/System/XSystemAnalytics.c \
 	GDKComponent/System/XGameRuntimeFeature.c \
 	GDKComponent/System/Networking/HTTPClient.c \
-	GDKComponent/System/Networking/XNetworking.c
+	GDKComponent/System/Networking/XNetworking.c \
+	GDKComponent/System/XGameProtocol.c
 

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -210,6 +210,10 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
     {
         return IXNetworkingImpl_QueryInterface( x_networking_impl, interfaceId, out );
     }
+    else if ( IsEqualGUID( runtimeClassId, &CLSID_XGameProtocolImpl ) )
+    {
+        return IXGameProtocolImpl_QueryInterface( x_gameprotocol_impl, interfaceId, out );
+    }
     
     FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );
     return E_NOTIMPL;

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -1,6 +1,6 @@
 /*
  * Xbox Game runtime Library
- * 
+ *
  * Written by Weather
  *
  * This library is free software; you can redistribute it and/or
@@ -53,6 +53,7 @@ extern IXSystemAnalyticsImpl *x_system_analytics_impl;
 extern IXThreadingImpl *x_threading_impl;
 extern IXGameRuntimeFeatureImpl *x_game_runtime_feature_impl;
 extern IXNetworkingImpl *x_networking_impl;
+extern IXGameProtocolImpl *x_gameprotocol_impl;
 
 typedef struct _INITIALIZE_OPTIONS
 {

--- a/dlls/xgameruntime/provider.idl
+++ b/dlls/xgameruntime/provider.idl
@@ -22,6 +22,8 @@
 
 import "propidl.idl";
 
+cpp_quote("#include <xtaskqueue.h>")
+
 // --- xgameruntime --- //
 typedef void* XSystemHandle;
 
@@ -31,15 +33,19 @@ typedef enum XGameRuntimeFeature XGameRuntimeFeature;
 
 typedef struct XVersion XVersion;
 typedef struct XSystemAnalyticsInfo XSystemAnalyticsInfo;
+typedef struct XTaskQueueObject* XTaskQueueHandle;
+typedef struct XTaskQueueRegistrationToken XTaskQueueRegistrationToken;
 
 interface IWineAsyncWorkImpl;
 interface IXSystemImpl;
 interface IXSystemAnalyticsImpl;
 interface IXGameRuntimeFeatureImpl;
+interface IXGameProtocolImpl;
 
 coclass XSystemImpl;
 coclass XSystemAnalyticsImpl;
 coclass XGameRuntimeFeatureImpl;
+coclass XGameProtocolImpl;
 
 enum XSystemHandleType
 {
@@ -163,6 +169,18 @@ interface IXGameRuntimeFeatureImpl : IUnknown
 }
 
 [
+    local,
+    object,
+    uuid(026b010c-06c3-4cdd-bbcb-43f229db1cff)
+]
+interface IXGameProtocolImpl : IUnknown
+{
+    HRESULT XGameProtocolRegisterForActivation( [in] XTaskQueueHandle queue, [in] void *context, [in] void *callback, [out] XTaskQueueRegistrationToken *token );
+    BOOLEAN XGameProtocolUnregisterForActivation( XTaskQueueRegistrationToken *token, boolean wait );
+    void XGameProtocolActivationCallback( [in] void *context, [in] LPSTR protocolUri );
+}
+
+[
     uuid(e349bd1a-fc20-4e40-b99c-4178cc6b409f)
 ]
 coclass XSystemImpl
@@ -184,5 +202,13 @@ coclass XSystemAnalyticsImpl
 coclass XGameRuntimeFeatureImpl
 {
     [default] interface IXGameRuntimeFeatureImpl;
+}
+
+[
+    uuid(95fd18d2-74dd-4d7c-aa1b-0b51827665d6)
+]
+coclass XGameProtocolImpl
+{
+    [default] interface IXGameProtocolImpl;
 }
 


### PR DESCRIPTION
Added some stubs for XGameProtocol (https://learn.microsoft.com/en-us/gaming/gdk/docs/reference/system/xgameprotocol/xgameprotocol_members?view=gdk-2510).

Minecraft GDK builds make an early call to XGameProtocolRegisterForActivation during startup and assert/crash on non-publish (i.e. partner) versions if the HRESULT isn't S_OK. Same deal for XGameProtocolUnregisterForActivation when closing the game if the result isn't true/false.

LMK if changes are needed since they are pretty quick and dirty stubs.