### PR TITLE
gameinput: Initialize mouseState.buttons before applying flags.

### DIFF
--- a/dlls/gameinput/mouinput.c
+++ b/dlls/gameinput/mouinput.c
@@ -302,6 +302,7 @@ HRESULT mouse_input_device_ReadCurrentStateFromDInput8( IN v2_IGameInputDevice *
         mouseState.wheelY = relativeWheelStore;
     }
 
+    mouseState.buttons = GameInputMouseNone;
     if ( GetAsyncKeyState( VK_LBUTTON ) & 0x8000 )
         mouseState.buttons |= GameInputMouseLeftButton;
     if ( GetAsyncKeyState( VK_RBUTTON ) & 0x8000 )


### PR DESCRIPTION
Fixes mouse button input not being registered.

mouseState.buttons was previously used with |= without being initialized, resulting in undefined behavior.