### PR TITLE
xgameruntime: Fix XblInitialize due to Optional Args

### DIFF
--- a/dlls/xgameruntime/GDKComponent/System/XSystem.c
+++ b/dlls/xgameruntime/GDKComponent/System/XSystem.c
@@ -70,14 +70,15 @@ static HRESULT WINAPI x_system_XSystemGetConsoleId( IXSystemImpl *iface, INT32 c
 
     TRACE( "iface %p, consoleIdSize %d, consoleId %p, consoleIdUsed %p\n", iface, consoleIdSize, consoleId, consoleIdUsed );
 
-    if ( !consoleId || !consoleIdUsed )
+    if ( !consoleId )
         return E_POINTER;
 
     if ( consoleIdSize < XSystemConsoleIdBytes )
         return HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER );
 
     strcpy_s( consoleId, consoleIdSize, Id );
-    *consoleIdUsed = strlen( Id ) + 1;
+    if( consoleIdUsed )
+        *consoleIdUsed = strlen( Id ) + 1;
     return S_OK;
 }
 
@@ -88,14 +89,15 @@ static HRESULT WINAPI x_system_XSystemGetXboxLiveSandboxId( IXSystemImpl *iface,
 
     TRACE( "iface %p, sandboxIdSize %d, sandboxId %p, sandboxIdUsed %p\n", iface, sandboxIdSize, sandboxId, sandboxIdUsed );
 
-    if ( !sandboxId || !sandboxIdUsed )
+    if ( !sandboxId )
         return E_POINTER;
 
     if ( sandboxIdSize < XSystemXboxLiveSandboxIdMaxBytes )
         return HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER );
 
     strcpy_s( sandboxId, sandboxIdSize, Id );
-    *sandboxIdUsed = strlen( Id ) + 1;
+    if( sandboxIdUsed )
+        *sandboxIdUsed = strlen( Id ) + 1;
     return S_OK;
 }
 

--- a/dlls/xgameruntime/GDKComponent/System/XSystem.c
+++ b/dlls/xgameruntime/GDKComponent/System/XSystem.c
@@ -77,7 +77,7 @@ static HRESULT WINAPI x_system_XSystemGetConsoleId( IXSystemImpl *iface, INT32 c
         return HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER );
 
     strcpy_s( consoleId, consoleIdSize, Id );
-    if( consoleIdUsed )
+    if ( consoleIdUsed )
         *consoleIdUsed = strlen( Id ) + 1;
     return S_OK;
 }
@@ -96,7 +96,7 @@ static HRESULT WINAPI x_system_XSystemGetXboxLiveSandboxId( IXSystemImpl *iface,
         return HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER );
 
     strcpy_s( sandboxId, sandboxIdSize, Id );
-    if( sandboxIdUsed )
+    if ( sandboxIdUsed )
         *sandboxIdUsed = strlen( Id ) + 1;
     return S_OK;
 }


### PR DESCRIPTION
- x_system_XSystemGetXboxLiveSandboxId is called without non null sandboxIdUsed

---

- XblInitialize winegdk found defects while debugging the MIT source code of xbox-live-gdk
  - With the current sdk XSystem has a different GUID than defined in winegdk provider.idl:
    - XSystemGetXboxLiveSandboxId => returned E_NOTIMPL
    - (not changed here, minecraft uses the guid already in winegdk, but will change as soon as the gdk sdk is updated)
 - XSystemGetXboxLiveSandboxId defect, sandboxIdUsed == NULL => E_POINTER this parameter is optional and an error aborts xbl init

Due to this is the XboxLiveApi rejecting any user add operation of XblContextCreateHandle with E_XBL_NOT_INITIALIZED.

Depends on XUser for sign in to proper initialize a User, only improves ABI compatibility.

Code that calls this with a NULL parameter wrapped in a xal adapter
https://github.com/microsoft/xbox-live-api/blob/dd61050a95039108489b9deef7ba5c0945573850/Source/Shared/xbox_live_app_config.cpp#L42