### PR TITLE
Minimal xbl

### DIFF
--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -122,32 +122,17 @@ BOOL WINAPI DllMain( HINSTANCE hinst, DWORD reason, void *reserved )
 
 typedef HRESULT (WINAPI *InitializeApiImplEx2_ext)( ULONG gdkVer, ULONG gsVer, CHAR mode, INITIALIZE_OPTIONS *options );
 
-void OnRemoteConnectShow(
-    _In_opt_ void* context,
-    _In_ uint32_t userIdentifier,
-    _In_ XUserPlatformOperation operation,
-    _In_z_ char const* url,
-    _In_z_ char const* code,
-    _In_ size_t qrCodeSize,
-    _In_reads_bytes_(qrCodeSize) void const* qrCode
-    ) {
-        (void)context;
-        printf("OnRemoteConnectShow %u %p %s %s\n", userIdentifier, operation, url, code);
-        fflush(stdout);
-    }
+void OnRemoteConnectShow(void* context, uint32_t userIdentifier, XUserPlatformOperation operation, char const* url, char const* code, size_t qrCodeSize, void const* qrCode) {
+    (void)context;
+    printf("OnRemoteConnectShow %u %p %s %s\n", userIdentifier, operation, url, code);
+    fflush(stdout);
+}
 
-void OnRemoteConnectClose(
-    _In_opt_ void* context,
-    _In_ uint32_t userIdentifier,
-    _In_ XUserPlatformOperation operation
-    ) {
-        (void)context;
-        printf("OnRemoteConnectClose %u %p\n", userIdentifier, operation);
-        fflush(stdout);
-    }
-
-
-typedef HRESULT (WINAPI *QueryApiImpl_ext)( const GUID *runtimeClassId, REFIID interfaceId, void **out );
+void OnRemoteConnectClose( void* context, uint32_t userIdentifier, XUserPlatformOperation operation ) {
+    (void)context;
+    printf("OnRemoteConnectClose %u %p\n", userIdentifier, operation);
+    fflush(stdout);
+}
 
 BOOL CALLBACK SetUpXgameruntimeCrossPlatformMode(PINIT_ONCE, PVOID, PVOID *) {
     xgameruntime_threading = LoadLibraryA("xgameruntime.dll.threading");
@@ -192,6 +177,8 @@ HRESULT WINAPI InitializeApiImpl( ULONG gdkVer, ULONG gsVer )
     TRACE("gdkVer %ld, gsVer %ld\n", gdkVer, gsVer);
     return InitializeApiImplEx2( gdkVer, gsVer, 0, NULL );
 }
+
+typedef HRESULT (WINAPI *QueryApiImpl_ext)( const GUID *runtimeClassId, REFIID interfaceId, void **out );
 
 HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, void **out )
 {

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -110,7 +110,6 @@ BOOL WINAPI DllMain( HINSTANCE hinst, DWORD reason, void *reserved )
     {
         case DLL_PROCESS_ATTACH:
             DisableThreadLibraryCalls(hinst);
-            xgameruntime_threading = LoadLibraryA("xgameruntime.dll.threading");
             break;
         case DLL_PROCESS_DETACH:
             if (reserved) break;
@@ -123,6 +122,52 @@ BOOL WINAPI DllMain( HINSTANCE hinst, DWORD reason, void *reserved )
 
 typedef HRESULT (WINAPI *InitializeApiImplEx2_ext)( ULONG gdkVer, ULONG gsVer, CHAR mode, INITIALIZE_OPTIONS *options );
 
+void OnRemoteConnectShow(
+    _In_opt_ void* context,
+    _In_ uint32_t userIdentifier,
+    _In_ XUserPlatformOperation operation,
+    _In_z_ char const* url,
+    _In_z_ char const* code,
+    _In_ size_t qrCodeSize,
+    _In_reads_bytes_(qrCodeSize) void const* qrCode
+    ) {
+        (void)context;
+        printf("OnRemoteConnectShow %u %p %s %s\n", userIdentifier, operation, url, code);
+        fflush(stdout);
+    }
+
+void OnRemoteConnectClose(
+    _In_opt_ void* context,
+    _In_ uint32_t userIdentifier,
+    _In_ XUserPlatformOperation operation
+    ) {
+        (void)context;
+        printf("OnRemoteConnectClose %u %p\n", userIdentifier, operation);
+        fflush(stdout);
+    }
+
+
+typedef HRESULT (WINAPI *QueryApiImpl_ext)( const GUID *runtimeClassId, REFIID interfaceId, void **out );
+
+BOOL CALLBACK SetUpXgameruntimeCrossPlatformMode(PINIT_ONCE, PVOID, PVOID *) {
+    xgameruntime_threading = LoadLibraryA("xgameruntime.dll.threading");
+    InitializeApiImplEx2_ext func = (InitializeApiImplEx2_ext)GetProcAddress( xgameruntime_threading, "InitializeApiImplEx2" );
+    if(func) {
+        HRESULT r = func(10002, 7822, 0x8 /* CrossPlatformMode */ | 0x2 /* Default */, 0);
+        if(r != S_OK) {
+            return TRUE;
+        }
+        IXUserPlatform*user;
+        QueryApiImpl(&CLSID_XUserImpl, &IID_IXUserPlatform, &user);
+        XUserPlatformRemoteConnectEventHandlers remoteConnect;
+        remoteConnect.context = NULL;
+        remoteConnect.show = &OnRemoteConnectShow;     // Display QR code/URL dialog
+        remoteConnect.close = &OnRemoteConnectClose;   // Close authentication dialog
+        IXUserImpl_XUserPlatformRemoteConnectSetEventHandlers(user, NULL, &remoteConnect);
+    }
+    return TRUE;
+}
+
 HRESULT WINAPI InitializeApiImplEx2( ULONG gdkVer, ULONG gsVer, CHAR mode, INITIALIZE_OPTIONS *options )
 {
     //  Initialization can be done however we want on our side.
@@ -131,6 +176,8 @@ HRESULT WINAPI InitializeApiImplEx2( ULONG gdkVer, ULONG gsVer, CHAR mode, INITI
     //  There's no documented information about what `INITIALIZE_OPTIONS` is,
     // and xgameruntime.lib never utilizes this argument anyway.
     TRACE("gdkVer %ld, gsVer %ld, mode %d, options %p stub!\n", gdkVer, gsVer, mode, options);
+    static INIT_ONCE once = INIT_ONCE_STATIC_INIT;
+    InitOnceExecuteOnce(&once, &SetUpXgameruntimeCrossPlatformMode, NULL, NULL);
     return GDKC_InitAPI( gdkVer, gsVer, mode, options );
 }
 
@@ -145,8 +192,6 @@ HRESULT WINAPI InitializeApiImpl( ULONG gdkVer, ULONG gsVer )
     TRACE("gdkVer %ld, gsVer %ld\n", gdkVer, gsVer);
     return InitializeApiImplEx2( gdkVer, gsVer, 0, NULL );
 }
-
-typedef HRESULT (WINAPI *QueryApiImpl_ext)( GUID *runtimeClassId, REFIID interfaceId, void **out );
 
 HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, void **out )
 {
@@ -178,37 +223,22 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
 
     TRACE("runtimeClassId %s, interfaceId %s, out %p\n", debugstr_guid(runtimeClassId), debugstr_guid(interfaceId), out);
 
-    if ( IsEqualGUID( runtimeClassId, &CLSID_XSystemImpl ) )
-    {
-        return IXSystemImpl_QueryInterface( x_system_impl, interfaceId, out );
-    }
-    else if ( IsEqualGUID( runtimeClassId, &CLSID_XGameRuntimeFeatureImpl ) )
+    if ( IsEqualGUID( runtimeClassId, &CLSID_XGameRuntimeFeatureImpl ) )
     {
         return IXGameRuntimeFeatureImpl_QueryInterface( x_game_runtime_feature_impl, interfaceId, out );
-    }
-    else if ( IsEqualGUID( runtimeClassId, &CLSID_XSystemAnalyticsImpl ) )
-    {
-        return IXSystemAnalyticsImpl_QueryInterface( x_system_analytics_impl, interfaceId, out );
-    }
-    else if ( IsEqualGUID( runtimeClassId, &CLSID_XThreadingImpl ) )
-    {
-        /**
-         * For IXThreading, It's much better to use the native library instead.
-         */
-        if ( !func )
-        {
-            LoadOtherRuntime( &asked );
-            if ( !asked )
-            {
-                MessageBoxA( NULL, "The game has requested XThreading\nIt's recommended that you use Microsoft's native binary for this instead.\nTo do so, copy xgameruntime.dll from a Windows machine and place it under the name \"xgameruntime.dll.threading\" within either the game's binaries or within your prefix's system32 folder.\nYou won't be asked this again.", "Attention Required!", MB_ICONEXCLAMATION );
-            }
-            return IXThreadingImpl_QueryInterface( x_threading_impl, interfaceId, out );
-        }
-        return func( runtimeClassId, interfaceId, out );
     }
     else if ( IsEqualGUID( runtimeClassId, &CLSID_XNetworkingImpl ) )
     {
         return IXNetworkingImpl_QueryInterface( x_networking_impl, interfaceId, out );
+    }
+    else if(func && func(runtimeClassId, interfaceId, out) == S_OK)
+    {
+        return S_OK;
+    }
+    else if(!func)
+    {
+        MessageBoxA( NULL, "The game requires the original xgameruntime.dll for Sign in!\nIt's recommended that you use Microsoft's native binary for this instead.\nTo do so, copy xgameruntime.dll from a Windows machine and place it under the name \"xgameruntime.dll.threading\" within either the game's binaries or within your prefix's system32 folder.\n", "Attention Required!", MB_ICONEXCLAMATION );
+        abort();
     }
     
     FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -223,22 +223,41 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
 
     TRACE("runtimeClassId %s, interfaceId %s, out %p\n", debugstr_guid(runtimeClassId), debugstr_guid(interfaceId), out);
 
-    if ( IsEqualGUID( runtimeClassId, &CLSID_XGameRuntimeFeatureImpl ) )
+    if ( !func && IsEqualGUID( runtimeClassId, &CLSID_XSystemImpl ) )
+    {
+        return IXSystemImpl_QueryInterface( x_system_impl, interfaceId, out );
+    }
+    else if ( IsEqualGUID( runtimeClassId, &CLSID_XGameRuntimeFeatureImpl ) )
     {
         return IXGameRuntimeFeatureImpl_QueryInterface( x_game_runtime_feature_impl, interfaceId, out );
+    }
+    else if ( !func && IsEqualGUID( runtimeClassId, &CLSID_XSystemAnalyticsImpl ) )
+    {
+        return IXSystemAnalyticsImpl_QueryInterface( x_system_analytics_impl, interfaceId, out );
+    }
+    else if ( IsEqualGUID( runtimeClassId, &CLSID_XThreadingImpl ) )
+    {
+        /**
+         * For IXThreading, It's much better to use the native library instead.
+         */
+        if ( !func )
+        {
+            LoadOtherRuntime( &asked );
+            if ( !asked )
+            {
+                MessageBoxA( NULL, "The game has requested XThreading\nIt's recommended that you use Microsoft's native binary for this instead.\nTo do so, copy xgameruntime.dll from a Windows machine and place it under the name \"xgameruntime.dll.threading\" within either the game's binaries or within your prefix's system32 folder.\nYou won't be asked this again.", "Attention Required!", MB_ICONEXCLAMATION );
+            }
+            return IXThreadingImpl_QueryInterface( x_threading_impl, interfaceId, out );
+        }
+        return func( runtimeClassId, interfaceId, out );
     }
     else if ( IsEqualGUID( runtimeClassId, &CLSID_XNetworkingImpl ) )
     {
         return IXNetworkingImpl_QueryInterface( x_networking_impl, interfaceId, out );
     }
-    else if(func && func(runtimeClassId, interfaceId, out) == S_OK)
+    else if( func && func( runtimeClassId, interfaceId, out ) == S_OK )
     {
         return S_OK;
-    }
-    else if(!func)
-    {
-        MessageBoxA( NULL, "The game requires the original xgameruntime.dll for Sign in!\nIt's recommended that you use Microsoft's native binary for this instead.\nTo do so, copy xgameruntime.dll from a Windows machine and place it under the name \"xgameruntime.dll.threading\" within either the game's binaries or within your prefix's system32 folder.\n", "Attention Required!", MB_ICONEXCLAMATION );
-        abort();
     }
     
     FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -178,7 +178,7 @@ HRESULT WINAPI InitializeApiImpl( ULONG gdkVer, ULONG gsVer )
     return InitializeApiImplEx2( gdkVer, gsVer, 0, NULL );
 }
 
-typedef HRESULT (WINAPI *QueryApiImpl_ext)( const GUID *runtimeClassId, REFIID interfaceId, void **out );
+typedef HRESULT (WINAPI *QueryApiImpl_ext)( GUID *runtimeClassId, REFIID interfaceId, void **out );
 
 HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, void **out )
 {

--- a/dlls/xgameruntime/provider.idl
+++ b/dlls/xgameruntime/provider.idl
@@ -21,6 +21,9 @@
 #pragma makedep header
 
 import "propidl.idl";
+import "xuser.idl";
+
+cpp_quote("#include <xtaskqueue.h>")
 
 // --- xgameruntime --- //
 typedef void* XSystemHandle;
@@ -31,11 +34,23 @@ typedef enum XGameRuntimeFeature XGameRuntimeFeature;
 
 typedef struct XVersion XVersion;
 typedef struct XSystemAnalyticsInfo XSystemAnalyticsInfo;
+typedef struct XAsyncBlock XAsyncBlock;
+typedef struct XTaskQueueObject* XTaskQueueHandle;
+typedef struct XTaskQueueRegistrationToken XTaskQueueRegistrationToken;
+
+typedef void XAsyncCompletionRoutine(struct XAsyncBlock* asyncBlock);
 
 interface IWineAsyncWorkImpl;
 interface IXSystemImpl;
 interface IXSystemAnalyticsImpl;
 interface IXGameRuntimeFeatureImpl;
+interface IXUserBase;
+interface IXUserAddWithUi;
+interface IXUserMsa;
+interface IXUserStore;
+interface IXUserPlatform;
+interface IXUserSignOut;
+interface IXUserImpl;
 
 coclass XSystemImpl;
 coclass XSystemAnalyticsImpl;
@@ -163,6 +178,123 @@ interface IXGameRuntimeFeatureImpl : IUnknown
 }
 
 [
+    local,
+    object,
+    uuid(01acd177-91f9-4763-a38e-ccbb55ce32e0)
+]
+interface IXUserBase : IUnknown
+{
+    HRESULT XUserDuplicateHandle( [in] XUserHandle user, [out] XUserHandle *duplicated);
+    void XUserCloseHandle( [in] XUserHandle user );
+    INT32 XUserCompare( [in] XUserHandle user1, [in] XUserHandle user2 );
+    HRESULT XUserGetMaxUsers( [out] UINT32 *maxUsers );
+    HRESULT XUserAddAsync( [in] XUserAddOptions options, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserAddResult( [in,out] XAsyncBlock *asyncBlock, [out] XUserHandle *user );
+    HRESULT XUserGetLocalId( [in] XUserHandle user, [out] XUserLocalId *localId );
+    HRESULT XUserFindUserByLocalId( [in] XUserLocalId localId, [out] XUserHandle *user );
+    HRESULT XUserGetId( [in] XUserHandle user, [out] UINT64 *userId );
+    HRESULT XUserFindUserById( [in] UINT64 userId, [out] XUserHandle *user );
+    HRESULT XUserGetIsGuest( [in] XUserHandle user, [out] BOOLEAN *isGuest );
+    HRESULT XUserGetState( [in] XUserHandle user, [out] XUserState *state );
+    HRESULT __PADDING__();
+    HRESULT XUserGetGamerPictureAsync( [in] XUserHandle user, [in] XUserGamerPictureSize size, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserGetGamerPictureResultSize( [in,out] XAsyncBlock *asyncBlock, [out] SIZE_T *size );
+    HRESULT XUserGetGamerPictureResult( [in,out] XAsyncBlock *asyncBlock, [in] SIZE_T size, [out] void *buffer, [out] SIZE_T *used );
+    HRESULT XUserGetAgeGroup( [in] XUserHandle user, [out] XUserAgeGroup *group );
+    HRESULT XUserCheckPrivilege( [in] XUserHandle user, [in] XUserPrivilegeOptions options, [in] XUserPrivilege privilege, [out] BOOLEAN *hasPrivilege, [out] XUserPrivilegeDenyReason *reason );
+    HRESULT XUserResolvePrivilegeWithUiAsync( [in] XUserHandle user, [in] XUserPrivilegeOptions options, [in] XUserPrivilege privilege, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserResolvePrivilegeWithUiResult( [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserGetTokenAndSignatureAsync( [in] XUserHandle user, [in] XUserGetTokenAndSignatureOptions options, [in] LPCSTR method, [in] LPCSTR url, [in] SIZE_T count, [in] const XUserGetTokenAndSignatureHttpHeader *headers, [in] SIZE_T size, [in] const void *buffer, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserGetTokenAndSignatureResultSize( [in,out] XAsyncBlock *asyncBlock, [out] SIZE_T *size );
+    HRESULT XUserGetTokenAndSignatureResult( [in,out] XAsyncBlock *asyncBlock, [in] SIZE_T size, [out] void *buffer, [out] XUserGetTokenAndSignatureData **ptr, [out] SIZE_T *used );
+    HRESULT XUserGetTokenAndSignatureUtf16Async( [in] XUserHandle user, [in] XUserGetTokenAndSignatureOptions options, [in] LPCWSTR method, [in] LPCWSTR url, [in] SIZE_T count, [in] const XUserGetTokenAndSignatureUtf16HttpHeader *headers, [in] SIZE_T size, [in] const void *buffer, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserGetTokenAndSignatureUtf16ResultSize( [in,out] XAsyncBlock *asyncBlock, [out] SIZE_T *size );
+    HRESULT XUserGetTokenAndSignatureUtf16Result( [in,out] XAsyncBlock *asyncBlock, [in] SIZE_T size, [out] void *buffer, [out] XUserGetTokenAndSignatureUtf16Data **ptr, [out] SIZE_T *used );
+    HRESULT XUserResolveIssueWithUiAsync( [in] XUserHandle user, [in] LPCSTR url, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserResolveIssueWithUiResult( [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserResolveIssueWithUiUtf16Async( [in] XUserHandle user, [in] LPCWSTR url, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserResolveIssueWithUiUtf16Result( [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserRegisterForChangeEvent( [in] XTaskQueueHandle queue, [in] void *context, [in] XUserChangeEventCallback *callback, [in] XTaskQueueRegistrationToken *token );
+    BOOLEAN XUserUnregisterForChangeEvent( [in] XTaskQueueRegistrationToken token, [in] BOOLEAN wait );
+    HRESULT XUserGetSignOutDeferral( [out] XUserSignOutDeferralHandle *deferral );
+    void XUserCloseSignOutDeferralHandle( [in] XUserSignOutDeferralHandle deferral );
+}
+
+[
+    local,
+    object,
+    uuid(eb9bf948-18dc-4d82-bbcc-40e0a809c4c0)
+]
+interface IXUserAddWithUi : IXUserBase
+{
+    HRESULT XUserAddByIdWithUiAsync( [in] UINT64 userId, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserAddByIdWithUiResult( [in,out] XAsyncBlock *asyncBlock, [out] XUserHandle *user );
+}
+
+[
+    local,
+    object,
+    uuid(1bf2f8c5-d507-4e52-bb05-f726d0e71161)
+]
+interface IXUserMsa : IXUserAddWithUi
+{
+    HRESULT XUserGetMsaTokenSilentlyAsync( [in] XUserHandle user, [in] XUserGetMsaTokenSilentlyOptions options, [in] LPCSTR scope, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserGetMsaTokenSilentlyResult( [in,out] XAsyncBlock *asyncBlock, [in] SIZE_T size, [out] LPSTR token, [out] SIZE_T *used );
+    HRESULT XUserGetMsaTokenSilentlyResultSize( [in,out] XAsyncBlock *asyncBlock, [out] SIZE_T *size );
+}
+
+[
+    local,
+    object,
+    uuid(079415e3-6727-437f-8e9d-8f8f9b2439f7)
+]
+interface IXUserStore : IXUserMsa
+{
+    BOOLEAN XUserIsStoreUser( [in] XUserHandle user );
+}
+
+[
+    local,
+    object,
+    uuid(26f3c674-a2fe-44fa-b6c4-a323bc94ff53)
+]
+interface IXUserPlatform : IXUserStore
+{
+    HRESULT XUserPlatformRemoteConnectSetEventHandlers( [in] XTaskQueueHandle queue, [in] XUserPlatformRemoteConnectEventHandlers *handlers );
+    HRESULT XUserPlatformRemoteConnectCancelPrompt( [in] XUserPlatformOperation operation );
+    HRESULT XUserPlatformSpopPromptSetEventHandlers( [in] XTaskQueueHandle queue, [in] XUserPlatformSpopPromptEventHandler *handler, [in] void *context );
+    HRESULT XUserPlatformSpopPromptComplete( [in] XUserPlatformOperation operation, [in] XUserPlatformOperationResult result );
+}
+
+[
+    local,
+    object,
+    uuid(5131d685-4394-4ee6-8c18-bfb5d4aef1ff)
+]
+interface IXUserSignOut : IXUserPlatform
+{
+    BOOLEAN XUserIsSignOutPresent();
+    HRESULT XUserSignOutAsync( [in] XUserHandle user, [in,out] XAsyncBlock *asyncBlock );
+    HRESULT XUserSignOutResult( [in,out] XAsyncBlock *asyncBlock );
+}
+
+[
+    object
+]
+interface IXUserImpl : IXUserSignOut
+{}
+
+[
+    local,
+    object,
+    uuid(cef4fac0-7676-4a94-a119-4c43f9eb5b74)
+]
+interface IXUserGamertag : IUnknown
+{
+    HRESULT XUserGetGamertag( [in] XUserHandle user, [in] XUserGamertagComponent component, [in] SIZE_T size, [out] LPSTR gamertag, [out] SIZE_T *used );
+}
+
+[
     uuid(e349bd1a-fc20-4e40-b99c-4178cc6b409f)
 ]
 coclass XSystemImpl
@@ -186,3 +318,11 @@ coclass XGameRuntimeFeatureImpl
     [default] interface IXGameRuntimeFeatureImpl;
 }
 
+[
+    uuid(01acd177-91f9-4763-a38e-ccbb55ce32e0)
+]
+coclass XUserImpl
+{
+    [default] interface IXUserImpl;
+    interface IXUserGamertag;
+}

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1104,6 +1104,7 @@ SOURCES = \
 	xmllite.idl \
 	xpsobjectmodel.idl \
 	xpsobjectmodel_1.idl \
+	xuser.idl \
 	zmouse.h
 
 INSTALL_LIB = \

--- a/include/xuser.idl
+++ b/include/xuser.idl
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 Olivia Ryan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+import "propidl.idl";
+
+typedef PVOID XUserPlatformOperation;
+typedef PVOID XUserHandle;
+typedef PVOID XUserSignOutDeferralHandle;
+
+typedef enum XUserAddOptions XUserAddOptions;
+typedef enum XUserAgeGroup XUserAgeGroup;
+typedef enum XUserChangeEvent XUserChangeEvent;
+typedef enum XUserDefaultAudioEndpointKind XUserDefaultAudioEndpointKind;
+typedef enum XUserGamerPictureSize XUserGamerPictureSize;
+typedef enum XUserGamertagComponent XUserGamertagComponent;
+typedef enum XUserGetMsaTokenSilentlyOptions XUserGetMsaTokenSilentlyOptions;
+typedef enum XUserGetTokenAndSignatureOptions XUserGetTokenAndSignatureOptions;
+typedef enum XUserPrivilege XUserPrivilege;
+typedef enum XUserPrivilegeDenyReason XUserPrivilegeDenyReason;
+typedef enum XUserPrivilegeOptions XUserPrivilegeOptions;
+typedef enum XUserState XUserState;
+typedef enum XUserPlatformOperationResult XUserPlatformOperationResult;
+typedef enum XUserPlatformSpopOperationResult XUserPlatformSpopOperationResult;
+
+typedef struct XUserDeviceAssociationChange XUserDeviceAssociationChange;
+typedef struct XUserGetTokenAndSignatureData XUserGetTokenAndSignatureData;
+typedef struct XUserGetTokenAndSignatureHttpHeader XUserGetTokenAndSignatureHttpHeader;
+typedef struct XUserGetTokenAndSignatureUtf16Data XUserGetTokenAndSignatureUtf16Data;
+typedef struct XUserGetTokenAndSignatureUtf16HttpHeader XUserGetTokenAndSignatureUtf16HttpHeader;
+typedef struct XUserLocalId XUserLocalId;
+typedef struct XUserPlatformRemoteConnectEventHandlers XUserPlatformRemoteConnectEventHandlers;
+
+typedef void (__stdcall *XUserChangeEventCallback)( PVOID context, XUserLocalId userLocalId, XUserChangeEvent event );
+typedef void (__stdcall *XUserDefaultAudioEndpointUtf16ChangedCallback)( PVOID context, XUserLocalId userLocalId, XUserDefaultAudioEndpointKind defaultAudioEndpointKind, LPCWSTR endpointIdUtf16 );
+typedef void (__stdcall *XUserDeviceAssociationChangedCallback)( PVOID context, const XUserDeviceAssociationChange *change );
+typedef void (__stdcall *XUserPlatformRemoteConnectShowPromptEventHandler)( PVOID context, UINT32 userIdentifier, XUserPlatformOperation operation, LPCSTR url, LPCSTR code, SIZE_T qrCodeSize, const PVOID qrCode );
+typedef void (__stdcall *XUserPlatformRemoteConnectClosePromptEventHandler)( PVOID context, UINT32 userIdentifier, XUserPlatformOperation operation );
+typedef void (__stdcall *XUserPlatformSpopPromptEventHandler)( PVOID context, UINT32 userIdentifier, XUserPlatformOperation operation, LPCSTR modernGamertag, LPCSTR modernGamertagSuffix );
+
+cpp_quote("#if 0")
+typedef unsigned __int64 uint64_t;
+typedef __int64 int64_t;
+typedef unsigned __int3264 size_t;
+typedef unsigned int uint32_t;
+typedef int int32_t;
+typedef unsigned short uint16_t;
+typedef unsigned char uint8_t;
+typedef boolean bool;
+typedef struct APP_LOCAL_DEVICE_ID
+{
+    BYTE value[32];
+} APP_LOCAL_DEVICE_ID;
+cpp_quote("#endif")
+
+enum XUserAddOptions
+{
+    XUserAddOptions_None                        = 0,
+    XUserAddOptions_AddDefaultUserSilently      = 1,
+    XUserAddOptions_AllowGuests                 = 2,
+    XUserAddOptions_AddDefaultUserAllowingUI    = 4
+};
+
+enum XUserAgeGroup
+{
+    XUserAgeGroup_Unknown   = 0,
+    XUserAgeGroup_Child     = 1,
+    XUserAgeGroup_Teen      = 2,
+    XUserAgeGroup_Adult     = 3
+};
+
+enum XUserChangeEvent
+{
+    XUserChangeEvent_SignedInAgain  = 0,
+    XUserChangeEvent_SigningOut     = 1,
+    XUserChangeEvent_SignedOut      = 2,
+    XUserChangeEvent_Gamertag       = 3,
+    XUserChangeEvent_GamerPicture   = 4,
+    XUserChangeEvent_Privileges     = 5
+};
+
+enum XUserDefaultAudioEndpointKind
+{
+    XUserDefaultAudioEndpointKind_CommunicationRender   = 0,
+    XUserDefaultAudioEndpointKind_CommunicationCapture  = 1
+};
+
+enum XUserGamerPictureSize
+{
+    XUserGamerPictureSize_Small         = 0,
+    XUserGamerPictureSize_Medium        = 1,
+    XUserGamerPictureSize_Large         = 2,
+    XUserGamerPictureSize_ExtraLarge    = 3
+};
+
+enum XUserGamertagComponent
+{
+    XUserGamertagComponent_Classic      = 0,
+    XUserGamertagComponent_Modern       = 1,
+    XUserGamertagComponent_ModerSuffix  = 2,
+    XUserGamertagComponent_UniqueModern = 3
+};
+
+enum XUserGetMsaTokenSilentlyOptions
+{
+    XUserGetMsaTokenSilentlyOptions_None    = 0
+};
+
+enum XUserGetTokenAndSignatureOptions
+{
+    XUserGetTokenAndSignatureOptions_None           = 0,
+    XUserGetTokenAndSignatureOptions_ForceRefresh   = 1,
+    XUserGetTokenAndSignatureOptions_AllUsers       = 2
+};
+
+enum XUserPrivilege
+{
+    XUserPrivilege_CrossPlay            = 185,
+    XUserPrivilege_Clubs                = 188,
+    XUserPrivilege_Sessions             = 189,
+    XUserPrivilege_Broadcast            = 190,
+    XUserPrivilege_ManageProfilePrivacy = 196,
+    XUserPrivilege_GameDvr              = 198,
+    XUserPrivilege_MultiplayerParties   = 203,
+    XUserPrivilege_CloudManageSession   = 207,
+    XUserPrivilege_CloudJoinSession     = 208,
+    XUserPrivilege_CloudSavedGames      = 209,
+    XUserPrivilege_SocialNetworkSharing = 220,
+    XUserPrivilege_UserGeneratedContent = 247,
+    XUserPrivilege_Communications       = 252,
+    XUserPrivilege_Multiplayer          = 254,
+    XUserPrivilege_AddFriends           = 255
+};
+
+enum XUserPrivilegeDenyReason
+{
+    XUserPrivilegeDenyReason_None               = 0,
+    XUserPrivilegeDenyReason_PurchaseRequired   = 1,
+    XUserPrivilegeDenyReason_Restricted         = 2,
+    XUserPrivilegeDenyReason_Banned             = 3,
+    XUserPrivilegeDenyReason_Unknown            = -1
+};
+
+enum XUserPrivilegeOptions
+{
+    XUserPrivilegeOptions_None      = 0,
+    XUserPrivilegeOptions_AllUsers  = 1
+};
+
+enum XUserState
+{
+    XUserState_SignedIn     = 0,
+    XUserState_SigningOut   = 1,
+    XUserState_SignedOut    = 2
+};
+
+enum XUserPlatformOperationResult
+{
+    XUserPlatformOperationResult_Success    = 0,
+    XUserPlatformOperationResult_Failure    = 1,
+    XUserPlatformOperationResult_Canceled   = 2
+};
+
+enum XUserPlatformSpopOperationResult
+{
+    XUserPlatformSpopOperationResult_SignInHere     = 0,
+    XUserPlatformSpopOperationResult_SwitchAccount  = 1,
+    XUserPlatformSpopOperationResult_Failure        = 2,
+    XUserPlatformSpopOperationResult_Canceled       = 3
+};
+
+struct XUserLocalId {
+    UINT64 value;
+};
+
+struct XUserDeviceAssociationChange
+{
+    APP_LOCAL_DEVICE_ID deviceId;
+    XUserLocalId oldUser;
+    XUserLocalId newUser;
+};
+
+struct XUserGetTokenAndSignatureData {
+    SIZE_T tokenSize;
+    SIZE_T signatureSize;
+    LPCSTR token;
+    LPCSTR signature;
+};
+
+struct XUserGetTokenAndSignatureHttpHeader {
+    LPCSTR name;
+    LPCSTR value;
+};
+
+struct XUserGetTokenAndSignatureUtf16Data {
+    SIZE_T tokenCount;
+    SIZE_T signatureCount;
+    LPCWSTR token;
+    LPCWSTR signature;
+};
+
+struct XUserGetTokenAndSignatureUtf16HttpHeader {
+    LPCWSTR name;
+    LPCWSTR value;
+};
+
+struct XUserPlatformRemoteConnectEventHandlers {
+    XUserPlatformRemoteConnectShowPromptEventHandler* show;
+    XUserPlatformRemoteConnectClosePromptEventHandler* close;
+    PVOID context;
+};


### PR DESCRIPTION
WIP
- Missing UI, only TUI
- ~~Fallback to XUserless winegdk missing~~ Done

If you replace `MicrosoftGame.Config` with this content login to Minecraft works.
```
<?xml version="1.0" encoding="utf-8"?>
<Game configVersion="1">

  <Identity Name="MICROSOFT.MINECRAFTUWP"
            Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" 
            Version="1.26.1202.0" />

  <TitleId>67b57dac</TitleId>
  <MSAAppId>0000000048183522</MSAAppId>
  <StoreId>9NBLGGH2JHXJ</StoreId>

  <ExecutableList>
    <Executable Name="a.out"
                TargetDeviceFamily="PC"
                Id="Game" />
  </ExecutableList>


  <AdvancedUserModel>true</AdvancedUserModel>

  <MSAFullTrust>true</MSAFullTrust>
</Game>
```

I could also auto replace that in xgameruntime.dll here, e.g. pass the config as static string to the real xgameruntime.dll.

Idl of IXuser copyright @olivi-r .

This is clean room code and does not integrate any xbox live logic into winegdk that have to be reverse engineered.

The original `MicrosoftGame.Config` blocks sign in via the login flow the cross platform implementation uses