### PR TITLE
kernelbase: Add GetCurrentPackagePath2 and PackageName stubs

### DIFF
--- a/dlls/kernelbase/kernelbase.spec
+++ b/dlls/kernelbase/kernelbase.spec
@@ -495,6 +495,7 @@
 @ stdcall GetCurrentPackageId(ptr ptr)
 @ stdcall GetCurrentPackageInfo(long ptr ptr ptr)
 @ stdcall GetCurrentPackagePath(ptr ptr)
+@ stdcall GetCurrentPackagePath2(long ptr ptr)
 # @ stub GetCurrentPackageResourcesContext
 # @ stub GetCurrentPackageSecurityContext
 @ stdcall -norelay GetCurrentProcess() kernelbase_GetCurrentProcess
@@ -1049,14 +1050,14 @@
 @ stdcall OutputDebugStringA(str)
 @ stdcall OutputDebugStringW(wstr)
 # @ stub OverrideRoamingDataModificationTimesInRange
-# @ stub PackageFamilyNameFromFullName
+@ stdcall PackageFamilyNameFromFullName(wstr ptr ptr)
 # @ stub PackageFamilyNameFromId
 # @ stub PackageFamilyNameFromProductId
 # @ stub PackageFullNameFromId
 # @ stub PackageFullNameFromProductId
 @ stdcall PackageIdFromFullName(wstr long ptr ptr)
 # @ stub PackageIdFromProductId
-# @ stub PackageNameAndPublisherIdFromFamilyName
+@ stdcall PackageNameAndPublisherIdFromFamilyName(wstr ptr ptr ptr ptr)
 # @ stub PackageRelativeApplicationIdFromProductId
 # @ stub PackageSidFromFamilyName
 # @ stub PackageSidFromProductId

--- a/dlls/kernelbase/version.c
+++ b/dlls/kernelbase/version.c
@@ -1602,6 +1602,15 @@ LONG WINAPI /* DECLSPEC_HOTPATCH */ GetCurrentPackagePath( UINT32 *length, WCHAR
     return APPMODEL_ERROR_NO_PACKAGE;
 }
 
+/***********************************************************************
+ *         GetCurrentPackagePath2   (kernelbase.@)
+ */
+LONG WINAPI GetCurrentPackagePath2( UINT32 packagePathType, UINT32 *pathLength, WCHAR *path )
+{
+    FIXME( "(%u %p %p): stub\n", packagePathType, pathLength, path );
+    return APPMODEL_ERROR_NO_PACKAGE;
+}
+
 
 /***********************************************************************
  *         GetPackageFullName   (kernelbase.@)
@@ -1674,6 +1683,36 @@ static UINT32 processor_arch_from_string(const WCHAR *str, unsigned int len)
         if (lstrlenW(arch_names[i].name) == len && !wcsnicmp(str, arch_names[i].name, len))
             return arch_names[i].code;
     return ~0u;
+}
+
+/***********************************************************************
+ *         PackageFamilyNameFromFullName   (kernelbase.@)
+ */
+LONG WINAPI PackageFamilyNameFromFullName(const WCHAR *fullName, UINT32 *familyNameLength, WCHAR *familyName)
+{
+    FIXME( "(%s %p %p): stub\n", debugstr_w(fullName), familyNameLength, familyName );
+
+    if (!fullName || !familyNameLength)
+        return ERROR_INVALID_PARAMETER;
+
+    *familyNameLength = 0;
+    return ERROR_INSUFFICIENT_BUFFER;
+}
+
+/***********************************************************************
+ *         PackageNameAndPublisherIdFromFamilyName   (kernelbase.@)
+ */
+LONG WINAPI PackageNameAndPublisherIdFromFamilyName(const WCHAR *familyName, UINT32 *nameLength,
+                                                     WCHAR *name, UINT32 *publisherIdLength, WCHAR *publisherId)
+{
+    FIXME( "(%s %p %p %p %p): stub\n", debugstr_w(familyName), nameLength, name, publisherIdLength, publisherId );
+
+    if (!familyName || !nameLength || !publisherIdLength)
+        return ERROR_INVALID_PARAMETER;
+
+    *nameLength = 0;
+    *publisherIdLength = 0;
+    return ERROR_INSUFFICIENT_BUFFER;
 }
 
 /***********************************************************************

--- a/include/appmodel.h
+++ b/include/appmodel.h
@@ -129,7 +129,10 @@ LONG WINAPI AppPolicyGetProcessTerminationMethod(HANDLE token, AppPolicyProcessT
 LONG WINAPI AppPolicyGetShowDeveloperDiagnostic(HANDLE token, AppPolicyShowDeveloperDiagnostic *policy);
 LONG WINAPI AppPolicyGetThreadInitializationType(HANDLE token, AppPolicyThreadInitializationType *policy);
 LONG WINAPI AppPolicyGetWindowingModel(HANDLE processToken, AppPolicyWindowingModel *policy);
+LONG WINAPI GetCurrentPackagePath2(UINT32 packagePathType, UINT32 *pathLength, WCHAR *path);
+LONG WINAPI PackageFamilyNameFromFullName(const WCHAR *fullName, UINT32 *familyNameLength, WCHAR *familyName);
 LONG WINAPI PackageIdFromFullName(const WCHAR *full_name, UINT32 flags, UINT32 *buffer_length, BYTE *buffer);
+LONG WINAPI PackageNameAndPublisherIdFromFamilyName(const WCHAR *familyName, UINT32 *nameLength, WCHAR *name, UINT32 *publisherIdLength, WCHAR *publisherId);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
## Summary
- Add stub implementations of `GetCurrentPackagePath2`, `PackageFamilyNameFromFullName`, and `PackageNameAndPublisherIdFromFamilyName` to `dlls/kernelbase/version.c`
- Activate corresponding `.spec` entries in `dlls/kernelbase/kernelbase.spec` (replacing commented stubs)
- Add function declarations to `include/appmodel.h`

## Motivation
Minecraft Bedrock 1.26.21 imports these three package management APIs from kernelbase.dll. Without them, the game fails to launch on GDK-Proton (WineGDK-based Wine) due to unresolved imports. Previously this required binary-patching the executable with LIEF.

## Behavior
All three are minimal stubs following the existing pattern in `version.c`:
- **GetCurrentPackagePath2** — returns `APPMODEL_ERROR_NO_PACKAGE` (consistent with `GetCurrentPackagePath`)
- **PackageFamilyNameFromFullName** — validates parameters, sets length to 0, returns `ERROR_INSUFFICIENT_BUFFER`
- **PackageNameAndPublisherIdFromFamilyName** — validates parameters, sets lengths to 0, returns `ERROR_INSUFFICIENT_BUFFER`

Each function emits a `FIXME` trace and performs parameter validation before returning, matching the style of adjacent functions like `GetPackagesByPackageFamily` and `PackageIdFromFullName`.

## Test plan
- [ ] Verify Minecraft Bedrock 1.26.21 launches without LIEF binary patches on GDK-Proton
- [ ] Confirm `FIXME` traces appear in Wine debug output when the APIs are called
- [ ] Check that no regressions occur for existing package API stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)