### PR TITLE
windows.applicationmodel: Add ICoreApplication2/ICoreApplicationExit stubs with IPropertySet

### DIFF
--- a/dlls/twinapi.appcore/core_application.c
+++ b/dlls/twinapi.appcore/core_application.c
@@ -21,30 +21,385 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(twinapi);
 
-struct factory
+/* GDK/Xbox-specific GUID that Minecraft Bedrock queries for on the CoreApplication factory.
+ * Not present in standard Windows SDK headers but the game expects it. We route it to
+ * our ICoreApplication2 implementation since the game crashes (NULL deref) if QI fails. */
+static const GUID IID_ICoreApplication2_GDK = {0x17b0e613, 0x942a, 0x422d, {0x90,0x4c, 0xf9,0x0d,0xc7,0x1a,0x7d,0xae}};
+
+/* ========================================================================
+ * Stub IPropertySet / IMap<HSTRING,IInspectable*> implementation
+ *
+ * This is a static singleton empty property bag. It implements:
+ *   - IPropertySet (marker interface, no methods beyond IInspectable)
+ *   - IMap<HSTRING, IInspectable*> (Lookup, get_Size, HasKey, GetView, Insert, Remove, Clear)
+ *   - IObservableMap<HSTRING, IInspectable*> (add/remove_MapChanged)
+ *   - IIterable<IKeyValuePair<HSTRING, IInspectable*>> (First)
+ * All return empty/zero/false since the game just needs a valid object.
+ * ======================================================================== */
+
+struct property_set
 {
-    IActivationFactory IActivationFactory_iface;
+    IPropertySet IPropertySet_iface;
+    __FIMap_2_HSTRING_IInspectable IMap_iface;
+    __FIObservableMap_2_HSTRING_IInspectable IObservableMap_iface;
+    __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable IIterable_iface;
     LONG ref;
 };
 
-static inline struct factory *impl_from_IActivationFactory( IActivationFactory *iface )
+static struct property_set property_set_instance;
+
+/* --- IPropertySet --- */
+
+static HRESULT WINAPI prop_set_QueryInterface( IPropertySet *iface, REFIID iid, void **out )
 {
-    return CONTAINING_RECORD( iface, struct factory, IActivationFactory_iface );
+    struct property_set *impl = &property_set_instance;
+
+    TRACE( "iface %p, iid %s, out %p.\n", iface, debugstr_guid( iid ), out );
+
+    if (IsEqualGUID( iid, &IID_IUnknown ) ||
+        IsEqualGUID( iid, &IID_IInspectable ) ||
+        IsEqualGUID( iid, &IID_IAgileObject ) ||
+        IsEqualGUID( iid, &IID_IPropertySet ))
+    {
+        *out = &impl->IPropertySet_iface;
+        IPropertySet_AddRef( *out );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID___FIMap_2_HSTRING_IInspectable ))
+    {
+        *out = &impl->IMap_iface;
+        IPropertySet_AddRef( &impl->IPropertySet_iface );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID___FIObservableMap_2_HSTRING_IInspectable ))
+    {
+        *out = &impl->IObservableMap_iface;
+        IPropertySet_AddRef( &impl->IPropertySet_iface );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID___FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable ))
+    {
+        *out = &impl->IIterable_iface;
+        IPropertySet_AddRef( &impl->IPropertySet_iface );
+        return S_OK;
+    }
+
+    FIXME( "IPropertySet %s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( iid ) );
+    *out = NULL;
+    return E_NOINTERFACE;
+}
+
+static ULONG WINAPI prop_set_AddRef( IPropertySet *iface )
+{
+    struct property_set *impl = &property_set_instance;
+    return InterlockedIncrement( &impl->ref );
+}
+
+static ULONG WINAPI prop_set_Release( IPropertySet *iface )
+{
+    struct property_set *impl = &property_set_instance;
+    return InterlockedDecrement( &impl->ref );
+}
+
+static HRESULT WINAPI prop_set_GetIids( IPropertySet *iface, ULONG *iid_count, IID **iids )
+{
+    FIXME( "iface %p, iid_count %p, iids %p stub!\n", iface, iid_count, iids );
+    *iid_count = 0;
+    *iids = NULL;
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_set_GetRuntimeClassName( IPropertySet *iface, HSTRING *class_name )
+{
+    return WindowsCreateString( L"Windows.Foundation.Collections.PropertySet", 42, class_name );
+}
+
+static HRESULT WINAPI prop_set_GetTrustLevel( IPropertySet *iface, TrustLevel *trust_level )
+{
+    *trust_level = BaseTrust;
+    return S_OK;
+}
+
+static const struct IPropertySetVtbl prop_set_vtbl =
+{
+    prop_set_QueryInterface,
+    prop_set_AddRef,
+    prop_set_Release,
+    prop_set_GetIids,
+    prop_set_GetRuntimeClassName,
+    prop_set_GetTrustLevel,
+};
+
+/* --- IMap<HSTRING, IInspectable*> --- */
+
+static HRESULT WINAPI prop_map_QueryInterface( __FIMap_2_HSTRING_IInspectable *iface, REFIID iid, void **out )
+{
+    return prop_set_QueryInterface( &property_set_instance.IPropertySet_iface, iid, out );
+}
+
+static ULONG WINAPI prop_map_AddRef( __FIMap_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_AddRef( &property_set_instance.IPropertySet_iface );
+}
+
+static ULONG WINAPI prop_map_Release( __FIMap_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_Release( &property_set_instance.IPropertySet_iface );
+}
+
+static HRESULT WINAPI prop_map_GetIids( __FIMap_2_HSTRING_IInspectable *iface, ULONG *iid_count, IID **iids )
+{
+    return prop_set_GetIids( &property_set_instance.IPropertySet_iface, iid_count, iids );
+}
+
+static HRESULT WINAPI prop_map_GetRuntimeClassName( __FIMap_2_HSTRING_IInspectable *iface, HSTRING *class_name )
+{
+    return prop_set_GetRuntimeClassName( &property_set_instance.IPropertySet_iface, class_name );
+}
+
+static HRESULT WINAPI prop_map_GetTrustLevel( __FIMap_2_HSTRING_IInspectable *iface, TrustLevel *trust_level )
+{
+    return prop_set_GetTrustLevel( &property_set_instance.IPropertySet_iface, trust_level );
+}
+
+static HRESULT WINAPI prop_map_Lookup( __FIMap_2_HSTRING_IInspectable *iface, HSTRING key, IInspectable **value )
+{
+    FIXME( "key %s stub!\n", debugstr_hstring( key ) );
+    *value = NULL;
+    return E_BOUNDS;
+}
+
+static HRESULT WINAPI prop_map_get_Size( __FIMap_2_HSTRING_IInspectable *iface, unsigned int *size )
+{
+    *size = 0;
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_map_HasKey( __FIMap_2_HSTRING_IInspectable *iface, HSTRING key, boolean *found )
+{
+    *found = FALSE;
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_map_GetView( __FIMap_2_HSTRING_IInspectable *iface,
+                                         __FIMapView_2_HSTRING_IInspectable **view )
+{
+    FIXME( "stub!\n" );
+    *view = NULL;
+    return E_NOTIMPL;
+}
+
+static HRESULT WINAPI prop_map_Insert( __FIMap_2_HSTRING_IInspectable *iface,
+                                        HSTRING key, IInspectable *value, boolean *replaced )
+{
+    FIXME( "key %s stub!\n", debugstr_hstring( key ) );
+    if (replaced) *replaced = FALSE;
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_map_Remove( __FIMap_2_HSTRING_IInspectable *iface, HSTRING key )
+{
+    FIXME( "key %s stub!\n", debugstr_hstring( key ) );
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_map_Clear( __FIMap_2_HSTRING_IInspectable *iface )
+{
+    return S_OK;
+}
+
+static const struct __FIMap_2_HSTRING_IInspectableVtbl prop_map_vtbl =
+{
+    prop_map_QueryInterface,
+    prop_map_AddRef,
+    prop_map_Release,
+    prop_map_GetIids,
+    prop_map_GetRuntimeClassName,
+    prop_map_GetTrustLevel,
+    prop_map_Lookup,
+    prop_map_get_Size,
+    prop_map_HasKey,
+    prop_map_GetView,
+    prop_map_Insert,
+    prop_map_Remove,
+    prop_map_Clear,
+};
+
+/* --- IObservableMap<HSTRING, IInspectable*> --- */
+
+static HRESULT WINAPI prop_obsmap_QueryInterface( __FIObservableMap_2_HSTRING_IInspectable *iface, REFIID iid, void **out )
+{
+    return prop_set_QueryInterface( &property_set_instance.IPropertySet_iface, iid, out );
+}
+
+static ULONG WINAPI prop_obsmap_AddRef( __FIObservableMap_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_AddRef( &property_set_instance.IPropertySet_iface );
+}
+
+static ULONG WINAPI prop_obsmap_Release( __FIObservableMap_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_Release( &property_set_instance.IPropertySet_iface );
+}
+
+static HRESULT WINAPI prop_obsmap_GetIids( __FIObservableMap_2_HSTRING_IInspectable *iface, ULONG *iid_count, IID **iids )
+{
+    return prop_set_GetIids( &property_set_instance.IPropertySet_iface, iid_count, iids );
+}
+
+static HRESULT WINAPI prop_obsmap_GetRuntimeClassName( __FIObservableMap_2_HSTRING_IInspectable *iface, HSTRING *class_name )
+{
+    return prop_set_GetRuntimeClassName( &property_set_instance.IPropertySet_iface, class_name );
+}
+
+static HRESULT WINAPI prop_obsmap_GetTrustLevel( __FIObservableMap_2_HSTRING_IInspectable *iface, TrustLevel *trust_level )
+{
+    return prop_set_GetTrustLevel( &property_set_instance.IPropertySet_iface, trust_level );
+}
+
+static HRESULT WINAPI prop_obsmap_add_MapChanged( __FIObservableMap_2_HSTRING_IInspectable *iface,
+        __FIMapChangedEventHandler_2_HSTRING_IInspectable *handler, EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 100;
+    return S_OK;
+}
+
+static HRESULT WINAPI prop_obsmap_remove_MapChanged( __FIObservableMap_2_HSTRING_IInspectable *iface,
+        EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static const struct __FIObservableMap_2_HSTRING_IInspectableVtbl prop_obsmap_vtbl =
+{
+    prop_obsmap_QueryInterface,
+    prop_obsmap_AddRef,
+    prop_obsmap_Release,
+    prop_obsmap_GetIids,
+    prop_obsmap_GetRuntimeClassName,
+    prop_obsmap_GetTrustLevel,
+    prop_obsmap_add_MapChanged,
+    prop_obsmap_remove_MapChanged,
+};
+
+/* --- IIterable<IKeyValuePair<HSTRING, IInspectable*>> --- */
+
+static HRESULT WINAPI prop_iter_QueryInterface( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface, REFIID iid, void **out )
+{
+    return prop_set_QueryInterface( &property_set_instance.IPropertySet_iface, iid, out );
+}
+
+static ULONG WINAPI prop_iter_AddRef( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_AddRef( &property_set_instance.IPropertySet_iface );
+}
+
+static ULONG WINAPI prop_iter_Release( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface )
+{
+    return prop_set_Release( &property_set_instance.IPropertySet_iface );
+}
+
+static HRESULT WINAPI prop_iter_GetIids( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface, ULONG *iid_count, IID **iids )
+{
+    return prop_set_GetIids( &property_set_instance.IPropertySet_iface, iid_count, iids );
+}
+
+static HRESULT WINAPI prop_iter_GetRuntimeClassName( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface, HSTRING *class_name )
+{
+    return prop_set_GetRuntimeClassName( &property_set_instance.IPropertySet_iface, class_name );
+}
+
+static HRESULT WINAPI prop_iter_GetTrustLevel( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface, TrustLevel *trust_level )
+{
+    return prop_set_GetTrustLevel( &property_set_instance.IPropertySet_iface, trust_level );
+}
+
+static HRESULT WINAPI prop_iter_First( __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectable *iface,
+                                        __FIIterator_1___FIKeyValuePair_2_HSTRING_IInspectable **value )
+{
+    FIXME( "iface %p, value %p stub!\n", iface, value );
+    *value = NULL;
+    return E_NOTIMPL;
+}
+
+static const struct __FIIterable_1___FIKeyValuePair_2_HSTRING_IInspectableVtbl prop_iter_vtbl =
+{
+    prop_iter_QueryInterface,
+    prop_iter_AddRef,
+    prop_iter_Release,
+    prop_iter_GetIids,
+    prop_iter_GetRuntimeClassName,
+    prop_iter_GetTrustLevel,
+    prop_iter_First,
+};
+
+static struct property_set property_set_instance =
+{
+    {&prop_set_vtbl},
+    {&prop_map_vtbl},
+    {&prop_obsmap_vtbl},
+    {&prop_iter_vtbl},
+    1,
+};
+
+/* ========================================================================
+ * CoreApplication statics factory
+ * ======================================================================== */
+
+struct core_application_statics
+{
+    IActivationFactory IActivationFactory_iface;
+    ICoreApplication ICoreApplication_iface;
+    ICoreApplication2 ICoreApplication2_iface;
+    ICoreApplicationExit ICoreApplicationExit_iface;
+    LONG ref;
+};
+
+static inline struct core_application_statics *impl_from_IActivationFactory( IActivationFactory *iface )
+{
+    return CONTAINING_RECORD( iface, struct core_application_statics, IActivationFactory_iface );
 }
 
 static HRESULT WINAPI activation_factory_QueryInterface( IActivationFactory *iface, REFIID iid, void **out )
 {
-    struct factory *impl = impl_from_IActivationFactory( iface );
+    struct core_application_statics *impl = impl_from_IActivationFactory( iface );
 
-    TRACE( "iface %p, iid %s, out %p stub!\n", iface, debugstr_guid( iid ), out );
+    TRACE( "iface %p, iid %s, out %p.\n", iface, debugstr_guid( iid ), out );
 
     if (IsEqualGUID( iid, &IID_IUnknown ) ||
         IsEqualGUID( iid, &IID_IInspectable ) ||
         IsEqualGUID( iid, &IID_IAgileObject ) ||
         IsEqualGUID( iid, &IID_IActivationFactory ))
     {
-        IActivationFactory_AddRef( &impl->IActivationFactory_iface );
         *out = &impl->IActivationFactory_iface;
+        IInspectable_AddRef( *out );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID_ICoreApplication ))
+    {
+        *out = &impl->ICoreApplication_iface;
+        IInspectable_AddRef( *out );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID_ICoreApplication2 ) ||
+        IsEqualGUID( iid, &IID_ICoreApplication2_GDK ))
+    {
+        *out = &impl->ICoreApplication2_iface;
+        IInspectable_AddRef( *out );
+        return S_OK;
+    }
+
+    if (IsEqualGUID( iid, &IID_ICoreApplicationExit ))
+    {
+        *out = &impl->ICoreApplicationExit_iface;
+        IInspectable_AddRef( *out );
         return S_OK;
     }
 
@@ -55,17 +410,17 @@ static HRESULT WINAPI activation_factory_QueryInterface( IActivationFactory *ifa
 
 static ULONG WINAPI activation_factory_AddRef( IActivationFactory *iface )
 {
-    struct factory *impl = impl_from_IActivationFactory( iface );
+    struct core_application_statics *impl = impl_from_IActivationFactory( iface );
     ULONG ref = InterlockedIncrement( &impl->ref );
-    TRACE( "iface %p, ref %lu.\n", iface, ref );
+    TRACE( "iface %p increasing refcount to %lu.\n", iface, ref );
     return ref;
 }
 
 static ULONG WINAPI activation_factory_Release( IActivationFactory *iface )
 {
-    struct factory *impl = impl_from_IActivationFactory( iface );
+    struct core_application_statics *impl = impl_from_IActivationFactory( iface );
     ULONG ref = InterlockedDecrement( &impl->ref );
-    TRACE( "iface %p, ref %lu.\n", iface, ref );
+    TRACE( "iface %p decreasing refcount to %lu.\n", iface, ref );
     return ref;
 }
 
@@ -106,10 +461,218 @@ static const struct IActivationFactoryVtbl activation_factory_vtbl =
     activation_factory_ActivateInstance,
 };
 
-static struct factory factory =
+/* --- ICoreApplication --- */
+
+DEFINE_IINSPECTABLE_( core_app, ICoreApplication, struct core_application_statics,
+                       impl_from_ICoreApplication, ICoreApplication_iface, &impl->IActivationFactory_iface )
+
+static HRESULT WINAPI core_app_get_Id( ICoreApplication *iface, HSTRING *value )
+{
+    FIXME( "iface %p, value %p stub!\n", iface, value );
+    return WindowsCreateString( L"App", 3, value );
+}
+
+static HRESULT WINAPI core_app_add_Suspending( ICoreApplication *iface,
+        __FIEventHandler_1_Windows__CApplicationModel__CSuspendingEventArgs *handler, EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 1;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_remove_Suspending( ICoreApplication *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_add_Resuming( ICoreApplication *iface,
+        __FIEventHandler_1_IInspectable *handler, EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 2;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_remove_Resuming( ICoreApplication *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_get_Properties( ICoreApplication *iface, IPropertySet **value )
+{
+    TRACE( "iface %p, value %p.\n", iface, value );
+    *value = &property_set_instance.IPropertySet_iface;
+    IPropertySet_AddRef( *value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_GetCurrentView( ICoreApplication *iface, ICoreApplicationView **value )
+{
+    FIXME( "iface %p, value %p stub!\n", iface, value );
+    *value = NULL;
+    return E_NOTIMPL;
+}
+
+static HRESULT WINAPI core_app_Run( ICoreApplication *iface, IFrameworkViewSource *view_source )
+{
+    FIXME( "iface %p, view_source %p stub!\n", iface, view_source );
+    return E_NOTIMPL;
+}
+
+static HRESULT WINAPI core_app_RunWithActivationFactories( ICoreApplication *iface, IGetActivationFactory *factory )
+{
+    FIXME( "iface %p, factory %p stub!\n", iface, factory );
+    return E_NOTIMPL;
+}
+
+static const struct ICoreApplicationVtbl core_app_vtbl =
+{
+    core_app_QueryInterface,
+    core_app_AddRef,
+    core_app_Release,
+    /* IInspectable methods */
+    core_app_GetIids,
+    core_app_GetRuntimeClassName,
+    core_app_GetTrustLevel,
+    /* ICoreApplication methods */
+    core_app_get_Id,
+    core_app_add_Suspending,
+    core_app_remove_Suspending,
+    core_app_add_Resuming,
+    core_app_remove_Resuming,
+    core_app_get_Properties,
+    core_app_GetCurrentView,
+    core_app_Run,
+    core_app_RunWithActivationFactories,
+};
+
+/* --- ICoreApplication2 --- */
+
+DEFINE_IINSPECTABLE_( core_app2, ICoreApplication2, struct core_application_statics,
+                       impl_from_ICoreApplication2, ICoreApplication2_iface, &impl->IActivationFactory_iface )
+
+static HRESULT WINAPI core_app2_add_BackgroundActivated( ICoreApplication2 *iface,
+        __FIEventHandler_1_Windows__CApplicationModel__CActivation__CBackgroundActivatedEventArgs *handler,
+        EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 10;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_remove_BackgroundActivated( ICoreApplication2 *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_add_LeavingBackground( ICoreApplication2 *iface,
+        __FIEventHandler_1_Windows__CApplicationModel__CLeavingBackgroundEventArgs *handler,
+        EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 11;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_remove_LeavingBackground( ICoreApplication2 *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_add_EnteredBackground( ICoreApplication2 *iface,
+        __FIEventHandler_1_Windows__CApplicationModel__CEnteredBackgroundEventArgs *handler,
+        EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 12;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_remove_EnteredBackground( ICoreApplication2 *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app2_EnablePrelaunch( ICoreApplication2 *iface, boolean value )
+{
+    FIXME( "iface %p, value %d stub!\n", iface, value );
+    return S_OK;
+}
+
+static const struct ICoreApplication2Vtbl core_app2_vtbl =
+{
+    core_app2_QueryInterface,
+    core_app2_AddRef,
+    core_app2_Release,
+    /* IInspectable methods */
+    core_app2_GetIids,
+    core_app2_GetRuntimeClassName,
+    core_app2_GetTrustLevel,
+    /* ICoreApplication2 methods */
+    core_app2_add_BackgroundActivated,
+    core_app2_remove_BackgroundActivated,
+    core_app2_add_LeavingBackground,
+    core_app2_remove_LeavingBackground,
+    core_app2_add_EnteredBackground,
+    core_app2_remove_EnteredBackground,
+    core_app2_EnablePrelaunch,
+};
+
+/* --- ICoreApplicationExit --- */
+
+DEFINE_IINSPECTABLE_( core_app_exit, ICoreApplicationExit, struct core_application_statics,
+                       impl_from_ICoreApplicationExit, ICoreApplicationExit_iface, &impl->IActivationFactory_iface )
+
+static HRESULT WINAPI core_app_exit_Exit( ICoreApplicationExit *iface )
+{
+    FIXME( "iface %p stub!\n", iface );
+    ExitProcess( 0 );
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_exit_add_Exiting( ICoreApplicationExit *iface,
+        __FIEventHandler_1_IInspectable *handler, EventRegistrationToken *token )
+{
+    FIXME( "iface %p, handler %p, token %p stub!\n", iface, handler, token );
+    if (token) token->value = 3;
+    return S_OK;
+}
+
+static HRESULT WINAPI core_app_exit_remove_Exiting( ICoreApplicationExit *iface, EventRegistrationToken token )
+{
+    FIXME( "iface %p, token %#I64x stub!\n", iface, token.value );
+    return S_OK;
+}
+
+static const struct ICoreApplicationExitVtbl core_app_exit_vtbl =
+{
+    core_app_exit_QueryInterface,
+    core_app_exit_AddRef,
+    core_app_exit_Release,
+    /* IInspectable methods */
+    core_app_exit_GetIids,
+    core_app_exit_GetRuntimeClassName,
+    core_app_exit_GetTrustLevel,
+    /* ICoreApplicationExit methods */
+    core_app_exit_Exit,
+    core_app_exit_add_Exiting,
+    core_app_exit_remove_Exiting,
+};
+
+/* --- Static singleton --- */
+
+static struct core_application_statics core_application_statics =
 {
     {&activation_factory_vtbl},
+    {&core_app_vtbl},
+    {&core_app2_vtbl},
+    {&core_app_exit_vtbl},
     1,
 };
 
-IActivationFactory *core_application_factory = &factory.IActivationFactory_iface;
+IActivationFactory *core_application_factory = &core_application_statics.IActivationFactory_iface;


### PR DESCRIPTION
## Summary

- Add **ICoreApplication** static interface with `get_Id`, `Suspending`/`Resuming` events, `get_Properties`, `GetCurrentView`, `Run`, and `RunWithActivationFactories` stubs
- Add **ICoreApplication2** static interface with `BackgroundActivated`, `LeavingBackground`, `EnteredBackground` events and `EnablePrelaunch` stubs
- Add **ICoreApplicationExit** static interface with `Exit` (calls `ExitProcess`) and `Exiting` event stubs
- Add **IPropertySet** singleton stub implementing `IPropertySet`, `IMap<HSTRING,IInspectable*>`, `IObservableMap<HSTRING,IInspectable*>`, and `IIterable<IKeyValuePair<HSTRING,IInspectable*>>` as an empty property bag
- Handle GDK-specific `ICoreApplication2` GUID `{17b0e613-942a-422d-904c-f90dc71a7dae}` in QueryInterface alongside the standard one

## Motivation

Minecraft Bedrock (1.26.21 via GDK-Proton) activates `Windows.ApplicationModel.Core.CoreApplication` and queries the factory for `ICoreApplication2` using both the standard GUID and a GDK-specific GUID. The game crashes with a NULL dereference if QI fails. It also calls `ICoreApplication::get_Properties` which must return a valid `IPropertySet` object.

The existing implementation only had a bare `IActivationFactory` that returned `E_NOINTERFACE` for all WinRT interface queries.

## Changes

`dlls/twinapi.appcore/core_application.c`: Replaced the minimal factory stub with a full static singleton implementing the `CoreApplication` statics factory with `ICoreApplication`, `ICoreApplication2`, `ICoreApplicationExit`, and `IPropertySet` interfaces. All methods are stubs returning `S_OK` or `E_NOTIMPL` as appropriate. Uses `DEFINE_IINSPECTABLE_` macro consistent with other implementations in the DLL.

## Test plan

- [ ] Build WineGDK with the change
- [ ] Verify Minecraft Bedrock no longer crashes on CoreApplication WinRT activation
- [ ] Verify `get_Properties` returns a valid IPropertySet that supports QI for IMap/IObservableMap/IIterable
- [ ] Verify the GDK-specific GUID `{17b0e613-...}` is handled correctly in QI

🤖 Generated with [Claude Code](https://claude.com/claude-code)