### PR TITLE
ntdll: Fix NtQueryLicenseValue return and RtlGetDeviceFamilyInfoEnum device family

### DIFF
--- a/dlls/ntdll/rtl.c
+++ b/dlls/ntdll/rtl.c
@@ -1647,11 +1647,17 @@ char WINAPI RtlQueryProcessPlaceholderCompatibilityMode(void)
  */
 void WINAPI RtlGetDeviceFamilyInfoEnum(ULONGLONG *version, DWORD *family, DWORD *form)
 {
-    FIXME("%p %p %p: stub\n", version, family, form);
+    TRACE("%p %p %p\n", version, family, form);
 
-    if (version) *version = 0;
+    if (version)
+    {
+        PEB *peb = NtCurrentTeb()->Peb;
+        *version = ((ULONGLONG)peb->OSMajorVersion << 48) |
+                   ((ULONGLONG)peb->OSMinorVersion << 32) |
+                   ((ULONGLONG)peb->OSBuildNumber << 16);
+    }
     if (family) *family = DEVICEFAMILYINFOENUM_DESKTOP;
-    if (form) *form = DEVICEFAMILYDEVICEFORM_UNKNOWN;
+    if (form) *form = DEVICEFAMILYDEVICEFORM_DESKTOP;
 }
 
 /*********************************************************************

--- a/dlls/ntdll/unix/registry.c
+++ b/dlls/ntdll/unix/registry.c
@@ -870,7 +870,7 @@ NTSTATUS WINAPI NtQueryLicenseValue( const UNICODE_STRING *name, ULONG *type,
     }
 
     if (status == STATUS_OBJECT_NAME_NOT_FOUND)
-        FIXME( "License key %s not found\n", debugstr_w(name->Buffer) );
+        TRACE( "License key %s not found\n", debugstr_w(name->Buffer) );
 
     free( info );
     return status;


### PR DESCRIPTION
## Summary
- **NtQueryLicenseValue**: Downgrade FIXME to TRACE for unknown license keys. The function already correctly returns `STATUS_OBJECT_NAME_NOT_FOUND`, but the FIXME spam obscures real issues when applications query multiple keys.
- **RtlGetDeviceFamilyInfoEnum**: Populate the UAP version from PEB OS version fields instead of returning 0. Report `DEVICEFAMILYDEVICEFORM_DESKTOP` instead of `DEVICEFAMILYDEVICEFORM_UNKNOWN` to match the Desktop device family. Downgrade FIXME to TRACE since the function is now fully implemented.

## Motivation
Minecraft Bedrock (GDK build, 1.26.x) calls both functions during startup. The game queries `NtQueryLicenseValue` for license keys and handles "not found" gracefully, but the FIXME log noise obscures real debugging output. It also calls `RtlGetDeviceFamilyInfoEnum` to detect the device platform — the zero UAP version and unknown form factor cause the game to misidentify the environment.

## Test plan
- [ ] Verify `NtQueryLicenseValue` still returns `STATUS_OBJECT_NAME_NOT_FOUND` for unknown keys (no behavior change, only log level)
- [ ] Verify `RtlGetDeviceFamilyInfoEnum` returns non-zero version, `DEVICEFAMILYINFOENUM_DESKTOP` family, and `DEVICEFAMILYDEVICEFORM_DESKTOP` form
- [ ] Existing ntdll tests (`dlls/ntdll/tests/reg.c`, `dlls/ntdll/tests/rtl.c`) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)