### PR TITLE
Add stubs for XStore

### DIFF
--- a/dlls/xgameruntime/GDKComponent/System/XStore.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XStore.cpp
@@ -1,0 +1,554 @@
+/*
+ * Xbox Game runtime Library
+ *  GDK Component: System API -> XStore
+ *
+ * Copyright 2026 Olivia Ryan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "private.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
+
+class XStoreImpl : public IXStoreImpl6
+{
+public:
+    HRESULT WINAPI QueryInterface( REFIID iid, void **out ) override
+    {
+        TRACE( "iface %p, iid %s, out %p.\n", this, debugstr_guid( &iid ), out );
+
+        if (iid == __uuidof( IUnknown     ) ||
+            iid == __uuidof( IXStoreImpl  ) ||
+            iid == __uuidof( IXStoreImpl2 ) ||
+            iid == __uuidof( IXStoreImpl3 ) ||
+            iid == __uuidof( IXStoreImpl4 ) ||
+            iid == __uuidof( IXStoreImpl5 ) ||
+            iid == __uuidof( IXStoreImpl6 ))
+        {
+            AddRef();
+            *out = static_cast<IXStoreImpl6 *>(this);
+            return S_OK;
+        }
+
+        FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( &iid ) );
+        *out = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG WINAPI AddRef() override
+    {
+        ULONG ref = InterlockedIncrement( &this->ref );
+        TRACE( "iface %p increasing refcount to %lu.\n", this, ref );
+        return ref;
+    }
+
+    ULONG WINAPI Release() override
+    {
+        ULONG ref = InterlockedDecrement( &this->ref );
+        TRACE( "iface %p decreasing refcount to %lu.\n", this, ref );
+        return ref;
+    }
+
+    HRESULT WINAPI XStoreCreateContext( const XUserHandle user, XStoreContextHandle *storeContextHandle ) override
+    {
+        FIXME( "iface %p, user %p, storeContextHandle %p stub!\n", this, user, storeContextHandle );
+        return E_NOTIMPL;
+    }
+
+    void WINAPI XStoreCloseContextHandle( XStoreContextHandle storeContextHandle ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p stub!\n", this, storeContextHandle );
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage %u, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, const char **storeIds, SIZE_T storeIdsCount, const char **actionFilters, SIZE_T actionFiltersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, storeIds %p, storeIdsCount %Iu, actionFilters %p, actionFiltersCount %Iu, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), storeIds, storeIdsCount, actionFilters, actionFiltersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryEntitledProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage, %u, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryEntitledProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForCurrentGameAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForCurrentGameResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForPackageAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, packageIdentifier %s, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForPackageResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreEnumerateProductsQuery( const XStoreProductQueryHandle productQueryHandle, void *context, XStoreProductQueryCallback *callback ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, context %p, callback %p stub!\n", this, productQueryHandle, context, callback );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreProductsQueryHasMorePages( const XStoreProductQueryHandle productQueryHandle ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p stub!\n", this, productQueryHandle );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreProductsQueryNextPageAsync( const XStoreProductQueryHandle productQueryHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, async %p stub!\n", this, productQueryHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreProductsQueryNextPageResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    void WINAPI XStoreCloseProductsQueryHandle( XStoreProductQueryHandle productQueryHandle ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p stub!\n", this, productQueryHandle );
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForPackageAsync( const XStoreProductQueryHandle productQueryHandle, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, packageIdentifier %s, async %p stub!\n", this, productQueryHandle, debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForPackageResult( XAsyncBlock *async, XStoreLicenseHandle *storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, async %p, storeLicenseHandle %p stub!\n", this, async, storeLicenseHandle );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreIsLicenseValid( const XStoreLicenseHandle storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p stub!\n", this, storeLicenseHandle );
+        return FALSE;
+    }
+
+    void WINAPI XStoreCloseLicenseHandle( XStoreLicenseHandle storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p stub!\n", this, storeLicenseHandle );
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForStoreIdAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForStoreIdResult( XAsyncBlock *async, XStoreCanAcquireLicenseResult *storeCanAcquireLicense ) override
+    {
+        FIXME( "iface %p, async %p, storeCanAcquireLicense %p stub!\n", this, async, storeCanAcquireLicense );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForPackageAsync( const XStoreContextHandle storeContextHandle, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifier %s, async %p stub!\n", this, storeContextHandle, debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForPackageResult( XAsyncBlock *async, XStoreCanAcquireLicenseResult *storeCanAcquireLicense ) override
+    {
+        FIXME( "iface %p, async %p, storeCanAcquireLicense %p stub!\n", this, async, storeCanAcquireLicense );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameLicenseAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameLicenseResult( XAsyncBlock *async, XStoreGameLicense *license ) override
+    {
+        FIXME( "iface %p, async %p, license %p stub!\n", this, async, license );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesResult( XAsyncBlock *async, UINT32 count, XStoreAddonLicense *addOnLicenses ) override
+    {
+        FIXME( "iface %p, async %p, count %u, addOnLicenses %p stub!\n", this, async, count, addOnLicenses );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryConsumableBalanceRemainingAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryConsumableBalanceRemainingResult( XAsyncBlock *async, XStoreConsumableResult *consumableResult ) override
+    {
+        FIXME( "iface %p, async %p, consumableResult %p stub!\n", this, async, consumableResult );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreReportConsumableFulfillmentAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, UINT32 quantity, GUID trackingId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, quantity %u, trackingId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), quantity, debugstr_guid( &trackingId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreReportConsumableFulfillmentResult( XAsyncBlock *async, XStoreConsumableResult *consumableResult ) override
+    {
+        FIXME( "iface %p, async %p, consumableResult %p stub!\n", this, async, consumableResult );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdAsync( const XStoreContextHandle storeContextHandle, const char *serviceTicket, const char *publisherUserId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, serviceTicket %s, userId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( serviceTicket ), debugstr_a( publisherUserId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdAsync( const XStoreContextHandle storeContextHandle, const char *serviceTicket, const char *publisherUserId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, serviceTicket %s, publisherUserId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( serviceTicket ), debugstr_a( publisherUserId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenAsync( const XStoreContextHandle storeContextHandle, const char **productIds, SIZE_T productIdsCount, const char *customDeveloperString, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productIdsCount %p, idsCount %Iu, custom %s, async %p stub!\n", this, storeContextHandle, productIds, productIdsCount, debugstr_a( customDeveloperString ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING_2__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING_3__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowPurchaseUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, const char *name, const char *extendedJsonData, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, name %s, extendedJsonData %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), debugstr_a( name ), debugstr_a( extendedJsonData ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowPurchaseUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRateAndReviewUIAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRateAndReviewUIResult( XAsyncBlock *async, XStoreRateAndReviewResult *result ) override
+    {
+        FIXME( "iface %p, async %p, result %p stub!\n", this, async, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRedeemTokenUIAsync( const XStoreContextHandle storeContextHandle, const char *token, const char **allowedStoreIds, SIZE_T allowedStoreIdsCount, BOOLEAN disallowCsvRedemption, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, token %s, allowedStoreIds %p, allowedStoreIdsCount %Iu, disallowCsvRedemption %d, async %p stub!\n", this, storeContextHandle, debugstr_a( token ), allowedStoreIds, allowedStoreIdsCount, disallowCsvRedemption, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRedeemTokenUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesResult( XAsyncBlock *async, UINT32 count, XStorePackageUpdate *packageUpdates ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageUpdates %p stub!\n", this, async, count, packageUpdates );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadPackageUpdatesAsync( XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadPackageUpdatesResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackageUpdatesAsync( const XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackageUpdatesResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesAsync( const XStoreContextHandle storeContextHandle, const char **storeIds, SIZE_T storeIdsCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeIds %p, storeIdsCount %Iu, async %p stub!\n", this, storeContextHandle, storeIds, storeIdsCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesResult( XAsyncBlock *async, UINT32 count, char **packageIdentifiers ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageIdentifiers %p stub!\n", this, async, count, packageIdentifiers );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageIdentifier( const char *storeId, SIZE_T size, char *packageIdentifier ) override
+    {
+        FIXME( "iface %p, storeId %s, size %Iu, packageIdentifier %p stub!\n", this, debugstr_a( storeId ), size, packageIdentifier );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreRegisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueHandle queue, void *context, XStoreGameLicenseChangedCallback *callback, XTaskQueueRegistrationToken *token ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, queue %p, context %p, callback %p, token %p stub!\n", this, storeContextHandle, queue, context, callback, token );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreUnregisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, token %p, wait %d stub!\n", this, storeContextHandle, &token, wait );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreRegisterPackageLicenseLost( XStoreLicenseHandle storeLicenseHandle, XTaskQueueHandle queue, void *context, XStorePackageLicenseLostCallback *callback, XTaskQueueRegistrationToken *token) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p, queue %p, context %p, callback %p, token %p stub!\n", this, storeLicenseHandle, queue, context, callback, token );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreUnregisterPackageLicenseLost( XStoreLicenseHandle licenseHandle, XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        FIXME( "iface %p, licenseHandle %p, token %p, wait %d stub!\n", this, licenseHandle, &token, wait );
+        return FALSE;
+    }
+
+    BOOLEAN WINAPI XStoreIsAvailabilityPurchasable( const XStoreAvailability availability ) override
+    {
+        FIXME( "iface %p, availability %p stub!\n", this, &availability );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForDurablesAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForDurablesResult( XAsyncBlock *async, XStoreLicenseHandle *storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, async %p, storeLicenseHandle %p stub!\n", this, async, storeLicenseHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowAssociatedProductsUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XStoreProductKind productKinds, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, productKinds %#x, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), static_cast<UINT32>(productKinds), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowAssociatedProductsUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowProductPageUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowProductPageUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsForStoreIdAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, productKinds %#x, maxItemsToRetrievePerPage %u, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsForStoreIdResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesAsync( XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesResult( XAsyncBlock *async, UINT32 count, XStorePackageUpdate *packageUpdates ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageUpdates %p stub!\n", this, async, count, packageUpdates );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowGiftingUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, const char *name, const char *extendedJsonData, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, name %s, extendedJsonData %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), debugstr_a( name ), debugstr_a( extendedJsonData ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowGiftingUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+private:
+    LONG ref = 1;
+};
+
+static XStoreImpl g_x_store;
+
+IXStoreImpl *x_store = static_cast<IXStoreImpl *>(&g_x_store);

--- a/dlls/xgameruntime/Makefile.in
+++ b/dlls/xgameruntime/Makefile.in
@@ -24,6 +24,7 @@ SOURCES = \
 	GDKComponent/System/XSystemAnalytics.cpp \
 	GDKComponent/System/XNetworking.cpp \
 	GDKComponent/System/XUser.cpp \
+	GDKComponent/System/XStore.cpp \
 	\
 	GDKComponent/Xodus/Structs.cpp \
 	GDKComponent/Xodus/IPCLayer.cpp \

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -284,6 +284,8 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
         }
         return func( runtimeClassId, interfaceId, out );
     }
+    else if (IsEqualGUID( runtimeClassId, &CLSID_XStoreImpl ))
+        return IXStoreImpl_QueryInterface( x_store, interfaceId, out );
     
     FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );
     return E_NOTIMPL;

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -54,6 +54,7 @@
 #include <xuser.h>
 #include <xasync.h>
 #include <xasyncprovider.h>
+#include <xstore.h>
 
 #include "wine/unixlib.h"
 #include "wine/debug.h"
@@ -99,6 +100,7 @@ extern IXSystemImpl *x_system;
 extern IXSystemAnalyticsImpl *x_system_analytics;
 extern IXNetworkingImpl *x_networking;
 extern IXUserImpl *x_user;
+extern IXStoreImpl *x_store;
 
 #ifdef __cplusplus
 extern ABI::Xodus::IIPCLayer *xodus_ipclayer;

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1251,6 +1251,7 @@ SOURCES = \
 	xnetworking.idl \
 	xpsobjectmodel.idl \
 	xpsobjectmodel_1.idl \
+	xstore.idl \
 	xsystem.idl \
 	xtaskqueue.h \
 	xuser.idl \

--- a/include/xstore.idl
+++ b/include/xstore.idl
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) the Wine project
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+import "unknwn.idl";
+import "xasync.h";
+import "xuser.idl";
+
+cpp_quote("#if 0")
+typedef UINT64 time_t;
+cpp_quote("#endif")
+
+cpp_quote("#ifdef __cplusplus")
+
+cpp_quote("enum class XStoreCanLicenseStatus : UINT32")
+cpp_quote("{                                         ")
+cpp_quote("    NotLicensableToUser,                  ")
+cpp_quote("    Licensable,                           ")
+cpp_quote("    LicenseActionNotApplicableToProduct,  ")
+cpp_quote("};                                        ")
+
+cpp_quote("enum class XStoreDurationUnit : UINT32")
+cpp_quote("{                                     ")
+cpp_quote("    Minute,                           ")
+cpp_quote("    Hour,                             ")
+cpp_quote("    Day,                              ")
+cpp_quote("    Week,                             ")
+cpp_quote("    Month,                            ")
+cpp_quote("    Year,                             ")
+cpp_quote("};                                    ")
+
+cpp_quote("enum class XStoreProductKind : UINT32")
+cpp_quote("{                                    ")
+cpp_quote("    None = 0x00,                     ")
+cpp_quote("    Consumable = 0x01,               ")
+cpp_quote("    Durable = 0x02,                  ")
+cpp_quote("    Game = 0x04,                     ")
+cpp_quote("    Pass = 0x08,                     ")
+cpp_quote("    UnmanagedConsumable = 0x10,      ")
+cpp_quote("};                                   ")
+
+cpp_quote("#elif defined(__WINESRC__)")
+
+typedef enum XStoreCanLicenseStatus
+{
+    XStoreCanLicenseStatus_NotLicensableToUser,
+    XStoreCanLicenseStatus_Licensable,
+    XStoreCanLicenseStatus_LicenseActionNotApplicableToProduct,
+} XStoreCanLicenseStatus;
+
+typedef enum XStoreDurationUnit
+{
+    XStoreDurationUnit_Minute,
+    XStoreDurationUnit_Hour,
+    XStoreDurationUnit_Day,
+    XStoreDurationUnit_Week,
+    XStoreDurationUnit_Month,
+    XStoreDurationUnit_Year,
+} XStoreDurationUnit;
+
+typedef enum XStoreProductKind
+{
+    XStoreProductKind_None = 0x00,
+    XStoreProductKind_Consumable = 0x01,
+    XStoreProductKind_Durable = 0x02,
+    XStoreProductKind_Game = 0x04,
+    XStoreProductKind_Pass = 0x08,
+    XStoreProductKind_UnmanagedConsumable = 0x10,
+} XStoreProductKind;
+
+cpp_quote("#endif")
+
+typedef void *XStoreContextHandle;
+typedef void *XStoreLicenseHandle;
+typedef void *XStoreProductQueryHandle;
+
+typedef struct XStoreAddonLicense XStoreAddonLicense;
+typedef struct XStoreAvailability XStoreAvailability;
+typedef struct XStoreCanAcquireLicenseResult XStoreCanAcquireLicenseResult;
+typedef struct XStoreCollectionData XStoreCollectionData;
+typedef struct XStoreConsumableResult XStoreConsumableResult;
+typedef struct XStoreGameLicense XStoreGameLicense;
+typedef struct XStoreImage XStoreImage;
+typedef struct XStorePackageUpdate XStorePackageUpdate;
+typedef struct XStorePrice XStorePrice;
+typedef struct XStoreProduct XStoreProduct;
+typedef struct XStoreRateAndReviewResult XStoreRateAndReviewResult;
+typedef struct XStoreSku XStoreSku;
+typedef struct XStoreSubscriptionInfo XStoreSubscriptionInfo;
+typedef struct XStoreVideo XStoreVideo;
+
+typedef void    __stdcall XStoreGameLicenseChangedCallback( void *context );
+typedef void    __stdcall XStorePackageLicenseLostCallback( void *context );
+typedef BOOLEAN __stdcall XStoreProductQueryCallback( const XStoreProduct *product, void *context );
+
+struct XStoreAddonLicense
+{
+    char skuStoreId[18];
+    char inAppOfferToken[64];
+    BOOLEAN isActive;
+    time_t expirationDate;
+};
+
+struct XStorePrice
+{
+    float basePrice;
+    float price;
+    float recurrencePrice;
+    const char *currencyCode;
+    char formattedBasePrice[16];
+    char formattedPrice[16];
+    char formattedRecurrencePrice[16];
+    BOOLEAN isOnSale;
+    time_t saleEndDate;
+};
+
+struct XStoreAvailability
+{
+    const char *availabilityId;
+    XStorePrice price;
+    time_t endDate;
+};
+
+struct XStoreCanAcquireLicenseResult
+{
+    char licensableSku[5];
+    XStoreCanLicenseStatus status;
+};
+
+struct XStoreCollectionData
+{
+    time_t acquiredDate;
+    time_t startDate;
+    time_t endDate;
+    BOOLEAN isTrial;
+    UINT32 trialTimeRemainingInSeconds;
+    UINT32 quantity;
+    const char *campaignId;
+    const char *developerOfferId;
+};
+
+struct XStoreConsumableResult
+{
+    UINT32 quantity;
+};
+
+struct XStoreGameLicense
+{
+    char skuStoreId[18];
+    BOOLEAN isActive;
+    BOOLEAN isTrialOwnedByThisUser;
+    BOOLEAN isDiscLicense;
+    BOOLEAN isTrial;
+    UINT32 trialTimeRemainingInSeconds;
+    char trialUniqueId[64];
+    time_t expirationDate;
+};
+
+struct XStoreImage
+{
+    const char *uri;
+    UINT32 height;
+    UINT32 width;
+    const char *caption;
+    const char *imagePurposeTag;
+};
+
+struct XStorePackageUpdate
+{
+    char packageIdentifier[33];
+    BOOLEAN isMandatory;
+};
+
+struct XStoreProduct
+{
+    const char *storeId;
+    const char *title;
+    const char *description;
+    const char *language;
+    const char *inAppOfferToken;
+    char *linkUri;
+    XStoreProductKind productKind;
+    XStorePrice price;
+    BOOLEAN hasDigitalDownload;
+    BOOLEAN isInUserCollection;
+    UINT32 keywordsCount;
+    const char **keywords;
+    UINT32 skusCount;
+    XStoreSku *skus;
+    UINT32 imagesCount;
+    XStoreImage *images;
+    UINT32 videosCount;
+    XStoreVideo *videos;
+};
+
+struct XStoreRateAndReviewResult
+{
+    BOOLEAN wasUpdated;
+};
+
+struct XStoreSubscriptionInfo
+{
+    BOOLEAN hasTrialPeriod;
+    XStoreDurationUnit trialPeriodUnit;
+    UINT32 trialPeriod;
+    XStoreDurationUnit billingPeriodUnit;
+    UINT32 billingPeriod;
+};
+
+struct XStoreSku
+{
+    const char *skuId;
+    const char *title;
+    const char *description;
+    const char *language;
+    XStorePrice price;
+    BOOLEAN isTrial;
+    BOOLEAN isInUserCollection;
+    XStoreCollectionData collectionData;
+    BOOLEAN isSubscription;
+    XStoreSubscriptionInfo subscriptionInfo;
+    UINT32 bundledSkusCount;
+    const char **bundledSkus;
+    UINT32 imagesCount;
+    XStoreImage *images;
+    UINT32 videosCount;
+    XStoreVideo *videos;
+    UINT32 availabilitiesCount;
+    XStoreAvailability *availabilities;
+};
+
+struct XStoreVideo
+{
+    const char *uri;
+    UINT32 height;
+    UINT32 width;
+    const char *caption;
+    const char *videoPurposeTag;
+    XStoreImage previewImage;
+};
+
+cpp_quote("#ifdef __WINESRC__")
+
+[
+    local,
+    object,
+    uuid(0dd112ac-7c24-448c-b92b-3960fb5bd30c)
+]
+interface IXStoreImpl : IUnknown
+{
+    HRESULT XStoreCreateContext( [in, optional] const XUserHandle user, [out] XStoreContextHandle *storeContextHandle );
+    void    XStoreCloseContextHandle( [in] XStoreContextHandle storeContextHandle );
+    HRESULT XStoreQueryAssociatedProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAssociatedProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in, string, size_is(storeIdsCount,)] const char **storeIds, [in] SIZE_T storeIdsCount, [in, optional, string, size_is(actionFiltersCount,)] const char **actionFilters, [in] SIZE_T actionFiltersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryEntitledProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryEntitledProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductForCurrentGameAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductForCurrentGameResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductForPackageAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreEnumerateProductsQuery( [in] const XStoreProductQueryHandle productQueryHandle, [in, optional] void *context, [in] XStoreProductQueryCallback *callback );
+    BOOLEAN XStoreProductsQueryHasMorePages( [in] const XStoreProductQueryHandle productQueryHandle );
+    HRESULT XStoreProductsQueryNextPageAsync( [in] const XStoreProductQueryHandle productQueryHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreProductsQueryNextPageResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    void    XStoreCloseProductsQueryHandle( [in] XStoreProductQueryHandle productQueryHandle );
+    HRESULT XStoreAcquireLicenseForPackageAsync( [in] const XStoreProductQueryHandle productQueryHandle, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreAcquireLicenseForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreLicenseHandle *storeLicenseHandle );
+    BOOLEAN XStoreIsLicenseValid( [in] const XStoreLicenseHandle storeLicenseHandle );
+    void    XStoreCloseLicenseHandle( [in] XStoreLicenseHandle storeLicenseHandle );
+    HRESULT XStoreCanAcquireLicenseForStoreIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreCanAcquireLicenseForStoreIdResult( [in, out] XAsyncBlock *async, [out] XStoreCanAcquireLicenseResult *storeCanAcquireLicense );
+    HRESULT XStoreCanAcquireLicenseForPackageAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreCanAcquireLicenseForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreCanAcquireLicenseResult *storeCanAcquireLicense );
+    HRESULT XStoreQueryGameLicenseAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameLicenseResult( [in, out] XAsyncBlock *async, [out] XStoreGameLicense *license );
+    HRESULT XStoreQueryAddOnLicensesAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAddOnLicensesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryAddOnLicensesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStoreAddonLicense addOnLicenses[*] );
+    HRESULT XStoreQueryConsumableBalanceRemainingAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryConsumableBalanceRemainingResult( [in, out] XAsyncBlock *async, [out] XStoreConsumableResult *consumableResult );
+    HRESULT XStoreReportConsumableFulfillmentAsync( [in, out] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in] UINT32 quantity, [in] GUID trackingId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreReportConsumableFulfillmentResult( [in, out] XAsyncBlock *async, [out] XStoreConsumableResult *consumableResult );
+    HRESULT XStoreGetUserCollectionsIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *serviceTicket, [in, string] const char *publisherUserId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreGetUserCollectionsIdResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreGetUserCollectionsIdResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT XStoreGetUserPurchaseIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *serviceTicket, [in, string] const char *publisherUserId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreGetUserPurchaseIdResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreGetUserPurchaseIdResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT XStoreQueryLicenseTokenAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(productIdsCount,)] const char **productIds, [in] SIZE_T productIdsCount, [in, string] const char *customDeveloperString, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryLicenseTokenResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreQueryLicenseTokenResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT __PADDING__();
+    HRESULT __PADDING_2__();
+    HRESULT __PADDING_3__();
+    HRESULT XStoreShowPurchaseUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, optional, string] const char *name, [in, optional, string] const char *extendedJsonData, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowPurchaseUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRateAndReviewUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRateAndReviewUIResult( [in, out] XAsyncBlock *async, [out] XStoreRateAndReviewResult *result );
+    HRESULT XStoreShowRedeemTokenUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *token, [in, string, size_is(allowedStoreIdsCount,)] const char **allowedStoreIds, [in] SIZE_T allowedStoreIdsCount, [in] BOOLEAN disallowCsvRedemption, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRedeemTokenUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStorePackageUpdate packageUpdates[*] );
+    HRESULT XStoreDownloadPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadPackageUpdatesResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackageUpdatesResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackagesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(storeIdsCount,)] const char **storeIds, [in] SIZE_T storeIdsCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackagesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreDownloadAndInstallPackagesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, string, size_is(count,33)] char **packageIdentifiers );
+    HRESULT XStoreQueryPackageIdentifier( [in, string] const char *storeId, [in] SIZE_T size, [out, string, size_is(size)] char *packageIdentifier );
+    HRESULT XStoreRegisterGameLicenseChanged( [in] XStoreContextHandle storeContextHandle, [in] XTaskQueueHandle queue, [in, optional] void *context, [in] XStoreGameLicenseChangedCallback *callback, [out] XTaskQueueRegistrationToken *token );
+    BOOLEAN XStoreUnregisterGameLicenseChanged( [in] XStoreContextHandle storeContextHandle, [in] XTaskQueueRegistrationToken token, [in] BOOLEAN wait );
+    HRESULT XStoreRegisterPackageLicenseLost( [in] XStoreLicenseHandle licenseHandle, [in] XTaskQueueHandle queue, [in, optional] void *context, [in] XStorePackageLicenseLostCallback *callback, [out] XTaskQueueRegistrationToken *token );
+    BOOLEAN XStoreUnregisterPackageLicenseLost( [in] XStoreLicenseHandle licenseHandle, [in] XTaskQueueRegistrationToken token, [in] BOOLEAN wait );
+}
+
+[
+    local,
+    object,
+    uuid(60b09f4e-1b85-45b1-826c-169118e230e1)
+]
+interface IXStoreImpl2 : IXStoreImpl
+{
+    BOOLEAN XStoreIsAvailabilityPurchasable( [in] const XStoreAvailability availability );
+}
+
+[
+    local,
+    object,
+    uuid(2d42fea5-e71d-4b76-97cd-c50afbb3ae5d)
+]
+interface IXStoreImpl3 : IXStoreImpl2
+{
+    HRESULT XStoreAcquireLicenseForDurablesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreAcquireLicenseForDurablesResult( [in, out] XAsyncBlock *async, [out] XStoreLicenseHandle *storeLicenseHandle );
+}
+
+[
+    local,
+    object,
+    uuid(de3dbdd4-0b37-4bdb-a10e-acf3a354d06a)
+]
+interface IXStoreImpl4 : IXStoreImpl3
+{
+    HRESULT XStoreShowAssociatedProductsUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in] XStoreProductKind productKinds, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowAssociatedProductsUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowProductPageUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowProductPageUIResult( [in, out] XAsyncBlock *async );
+}
+
+[
+    local,
+    object,
+    uuid(5c48dedf-0b67-4492-a4b5-6829b8e796e1)
+]
+interface IXStoreImpl5 : IXStoreImpl4
+{
+    HRESULT XStoreQueryAssociatedProductsForStoreIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAssociatedProductsForStoreIdResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryPackageUpdatesAsync( [in] XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryPackageUpdatesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryPackageUpdatesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStorePackageUpdate packageUpdates[*] );
+}
+
+[
+    local,
+    object,
+    uuid(b09d803c-2414-4a05-82c6-66dfdc9e9a44)
+]
+interface IXStoreImpl6 : IXStoreImpl5
+{
+    HRESULT XStoreShowGiftingUIAsync( [in] XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, optional, string] const char *name, [in, optional, string] const char *extendedJsonData, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowGiftingUIResult( [in, out] XAsyncBlock *async );
+}
+
+[
+    uuid(0dd112ac-7c24-448c-b92b-3960fb5bd30c)
+]
+coclass XStoreImpl
+{
+    [default] interface IXStoreImpl6;
+}
+
+cpp_quote("#endif")


### PR DESCRIPTION
Stubs all XStore interfaces, implementation will likely require Xodus ipc, creating a context relies on an XUserHandle, but most of the actual requests can likely be done in xgameruntime itself.