### PR TITLE
Get Game Pass titles through sign-in

### DIFF
--- a/dlls/gameinput/mouinput.c
+++ b/dlls/gameinput/mouinput.c
@@ -30,6 +30,9 @@ WINE_DEFAULT_DEBUG_CHANNEL(ginput);
 extern HINSTANCE game_input;
 
 static GameInputMouseButtons storedButtons = GameInputMouseNone;
+/* The device info holds a borrowed pointer to this, so it has to outlive the caller's
+ * frame; there is a single system mouse, like storedButtons above assumes. */
+static v2_GameInputMouseInfo stored_mouse_info;
 static POINT relativePositionStore = {.x = 0, .y = 0};
 static LONG relativeWheelStore = 0;
 
@@ -149,7 +152,6 @@ HRESULT mouse_input_device_InitDevice( IN v2_IGameInputDevice *device )
     HIDP_VALUE_CAPS *valueCaps = NULL;
 
     v2_IGameInputDevice *dev = NULL;
-    v2_GameInputMouseInfo mouse_info;
     v2_GameInputDeviceInfo *device_info;
     GameInputMouseButtons buttons = GameInputMouseNone;
 
@@ -172,16 +174,24 @@ HRESULT mouse_input_device_InitDevice( IN v2_IGameInputDevice *device )
 
     // It is not possible to obtain sample rates from a HID device.
     // So we'll use a safe sample rate of 500 hz.
-    mouse_info.sampleRate = 500;
-    mouse_info.supportedButtons = buttons;
+    stored_mouse_info.sampleRate = 500;
+    stored_mouse_info.supportedButtons = buttons;
 
     // const override here!
     v2_IGameInputDevice_GetDeviceInfo( device, (const v2_GameInputDeviceInfo **)&device_info );
-    device_info->mouseInfo = &mouse_info;
+    device_info->mouseInfo = &stored_mouse_info;
 
-    // DInput device for mouse devices are manually acquired
+    /* DInput device for mouse devices are manually acquired. Devices are enumerated
+     * from GameInputCreate, before the title has a window, and DirectInput needs one
+     * for the cooperative level - so this fails on the first try. Keep the device
+     * anyway and let the read path acquire it later: dropping it here left the title
+     * with no mouse at all for the rest of the run. */
     hr = mouse_input_device_InitDInput8Device( device );
-    if ( FAILED( hr ) ) return hr;
+    if ( FAILED( hr ) )
+    {
+        WARN( "deferring DirectInput acquisition, hr %#lx.\n", hr );
+        hr = S_OK;
+    }
 
 _CLEANUP:
     if ( FAILED( hr ) )
@@ -272,14 +282,20 @@ HRESULT mouse_input_device_ReadCurrentStateFromDInput8( IN v2_IGameInputDevice *
     DIMOUSESTATE2 state;
     LPDIRECTINPUTDEVICE8W g_pDevice;
 
-    v2_GameInputMouseState mouseState;
+    v2_GameInputMouseState mouseState = { 0 };
 
     TRACE( "device %p, timestamp %lld, reading %p.\n", device, timestamp, reading );
 
     GetCursorPos( &absoluteP );
 
     hr = game_input_device_AcquireDInputDevice( device, &g_pDevice );
-    if ( FAILED( hr ) ) return hr;
+    if ( FAILED( hr ) || !g_pDevice )
+    {
+        /* Not acquired at enumeration time because there was no window yet. */
+        if ( FAILED( hr = mouse_input_device_InitDInput8Device( device ) ) ) return hr;
+        if ( FAILED( hr = game_input_device_AcquireDInputDevice( device, &g_pDevice ) ) ) return hr;
+        if ( !g_pDevice ) return E_FAIL;
+    }
 
     hr = g_pDevice->lpVtbl->GetDeviceState( g_pDevice, sizeof(state), &state );
     if ( FAILED( hr ) ) 

--- a/dlls/mmdevapi/devenum.c
+++ b/dlls/mmdevapi/devenum.c
@@ -832,6 +832,14 @@ static HRESULT WINAPI MMDevice_Activate(IMMDevice *iface, REFIID riid, DWORD cls
     }
     else if (IsEqualIID(riid, &IID_ISpatialAudioClient))
     {
+        /* Debug aid, not a fix: the spatial audio object reports itself as usable but
+         * offers zero dynamic objects, and Wwise crashes building its object map from
+         * that. Declining the interface makes callers fall back to ordinary WASAPI. */
+        if (getenv("WINE_DISABLE_SPATIAL_AUDIO"))
+        {
+            WARN("spatial audio disabled by WINE_DISABLE_SPATIAL_AUDIO\n");
+            return E_NOINTERFACE;
+        }
         hr = SpatialAudioClient_Create(iface, (ISpatialAudioClient**)ppv);
     }
     else

--- a/dlls/win32u/d3dkmt.c
+++ b/dlls/win32u/d3dkmt.c
@@ -710,6 +710,18 @@ NTSTATUS WINAPI NtGdiDdDDIQueryAdapterInfo( D3DKMT_QUERYADAPTERINFO *desc )
         *value = KMT_DRIVERVERSION_WDDM_3_1;
         return STATUS_SUCCESS;
     }
+    case KMTQAITYPE_WDDM_2_7_CAPS:
+    {
+        /* A 4-byte bitfield; all-zero means no GPU hardware scheduling. Callers use
+         * this to gauge how new the driver is, and treat a failed query as ancient. */
+        UINT *value = desc->pPrivateDriverData;
+
+        if (desc->PrivateDriverDataSize < sizeof(*value))
+            return STATUS_INVALID_PARAMETER;
+
+        *value = 0;
+        return STATUS_SUCCESS;
+    }
     default:
     {
         FIXME( "type %d not handled.\n", desc->Type );

--- a/dlls/win32u/sysparams.c
+++ b/dlls/win32u/sysparams.c
@@ -1144,7 +1144,7 @@ static const char* driver_vendor_to_version( UINT16 vendor )
     {
     case 0x8086: /* Intel */    return "35.0.101.6314";
     case 0x1002: /* AMD */      return "35.0.21025.1024";
-    case 0x10de: /* Nvidia */   return "35.0.15.6094";
+    case 0x10de: /* Nvidia */   return "35.0.16.1057"; /* 610.57 */
     default:                    return "35.0.10.1000";
     }
 }

--- a/dlls/windows.storage/private.h
+++ b/dlls/windows.storage/private.h
@@ -57,9 +57,9 @@
 #define WINDOWS_TICK 10000000
 #define SEC_TO_UNIX_EPOCH 11644473600LL
 
-extern IActivationFactory *random_access_stream_reference_factory;
-extern IActivationFactory *memory_stream_activation_factory;
-extern IActivationFactory *storage_folder_factory;
+EXTERN_C IActivationFactory *random_access_stream_reference_factory;
+EXTERN_C IActivationFactory *memory_stream_activation_factory;
+EXTERN_C IActivationFactory *storage_folder_factory;
 
 struct async_operation_iids
 {

--- a/dlls/xgameruntime/GDKComponent/InitInternalGDKC.cpp
+++ b/dlls/xgameruntime/GDKComponent/InitInternalGDKC.cpp
@@ -135,7 +135,8 @@ ObtainMsaAppId( INITIALIZE_OPTIONS *options )
                 else if ( !strcmp( (LPSTR)child->name, "TitleId" ) )
                 {
                     LPSTR value = (LPSTR)xmlNodeGetContent( child );
-                    titleId = strtoul( value, NULL, 10 );
+                    /* MicrosoftGame.Config writes the title id in hex. */
+                    titleId = strtoul( value, NULL, 16 );
                     free( value );
                 }
                 else if ( !strcmp( (LPSTR)child->name, "MSAFullTrust" ) )

--- a/dlls/xgameruntime/GDKComponent/System/Threading/XAsync.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/Threading/XAsync.cpp
@@ -22,6 +22,7 @@
 #include "XTaskQueue.h"
 
 #include <atomic>
+#include <cstring>
 #include <condition_variable>
 
 // Signatures can be anything because these are not exposed to the client.
@@ -405,10 +406,13 @@ static HRESULT AllocState(XAsyncBlock* asyncBlock, size_t contextSize)
         RETURN_HR(E_INVALIDARG);
     }
 
-    for (auto i = 0u; i < sizeof(asyncBlock->internal); ++i)
-    {
-        asyncBlock->internal[i] = 0;
-    }
+    /* Upstream declares internal as a byte array, so its element-wise loop clears
+     * sizeof(internal) bytes. Here it is an array of pointers, and the same loop
+     * would clear sizeof(internal) *pointers* - 256 bytes, 224 of them past the end
+     * of the caller's XAsyncBlock. Callers embed the block inside their own objects
+     * (XCurl puts it 0x288 into its easy handle), so that silently zeroed their
+     * fields on every async operation. */
+    memset(asyncBlock->internal, 0, sizeof(asyncBlock->internal));
 
     internal = new (asyncBlock->internal) AsyncBlockInternal{};
 
@@ -796,10 +800,14 @@ HRESULT WINAPI XAsyncSchedule(
         RETURN_HR(E_UNEXPECTED);
     }
 
-    TRACE("state->queue here is %p\n", state->queue);
+    /* Once the callback is submitted it owns the state and may already have run and
+     * released it, so remember the queue before handing ownership over. */
+    XTaskQueueHandle queue = state->queue;
+
+    TRACE("state->queue here is %p\n", queue);
 
     RETURN_IF_FAILED(XTaskQueueSubmitDelayedCallback(
-        state->queue,
+        queue,
         XTaskQueuePort::Work,
         delayInMs,
         state.Get(),
@@ -807,7 +815,7 @@ HRESULT WINAPI XAsyncSchedule(
 
     state.Detach();
 
-    TRACE("Before completion, queue here was %p\n", state->queue);
+    TRACE("Before completion, queue here was %p\n", queue);
 
     return S_OK;
 }

--- a/dlls/xgameruntime/GDKComponent/System/Threading/XTaskQueue.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/Threading/XTaskQueue.cpp
@@ -21,8 +21,25 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
 
+/* Defined below, next to the process queue globals it reads. */
+static XTaskQueueHandle GetProcessTaskQueueHandle();
+
 inline ITaskQueue* GetQueue(XTaskQueueHandle handle)
 {
+    /* A null handle means "use the process task queue" - libHttpClient submits its
+     * callbacks that way. It also has to be resolved before the signature check,
+     * which would otherwise dereference null. */
+    if (handle == nullptr)
+    {
+        handle = GetProcessTaskQueueHandle();
+
+        if (handle == nullptr)
+        {
+            WARN("no process task queue for a null XTaskQueueHandle\n");
+            return nullptr;
+        }
+    }
+
     if (handle->m_signature != TASK_QUEUE_SIGNATURE)
     {
         assert("Invalid XTaskQueueHandle");
@@ -49,6 +66,49 @@ namespace ProcessGlobals
 #ifdef SUSPEND_API
     SuspendState g_suspendState;
 #endif
+}
+
+/* Returns the queue set with XTaskQueueSetCurrentProcessTaskQueue, or the default
+ * process queue, creating it on first use. Borrowed - the refcount is untouched,
+ * so callers that hand the handle out have to duplicate it themselves. */
+static XTaskQueueHandle GetProcessTaskQueueHandle()
+{
+    XTaskQueueHandle processQueue = ProcessGlobals::g_processQueue;
+
+    if (processQueue == ProcessGlobals::g_invalidQueueHandle)
+    {
+        XTaskQueueHandle defaultProcessQueue = ProcessGlobals::g_defaultProcessQueue;
+
+        if (defaultProcessQueue == ProcessGlobals::g_invalidQueueHandle)
+        {
+            /* Completions run serialized: libHttpClient and XCurl hand their state
+             * between callbacks and corrupt it when two run at once. */
+            referenced_ptr<TaskQueueImpl> aq(new (std::nothrow) TaskQueueImpl);
+            if (aq != nullptr && SUCCEEDED(aq->Initialize(
+                XTaskQueueDispatchMode::ThreadPool,
+                XTaskQueueDispatchMode::SerializedThreadPool)))
+            {
+                XTaskQueueHandle expected = ProcessGlobals::g_invalidQueueHandle;
+                if (ProcessGlobals::g_defaultProcessQueue.compare_exchange_strong(
+                    expected,
+                    aq->GetHandle()))
+                {
+                    aq.release();
+                }
+            }
+
+            defaultProcessQueue = ProcessGlobals::g_defaultProcessQueue;
+        }
+
+        processQueue = defaultProcessQueue;
+    }
+
+    if (processQueue == ProcessGlobals::g_invalidQueueHandle)
+    {
+        processQueue = nullptr;
+    }
+
+    return processQueue;
 }
 
 /**
@@ -525,7 +585,11 @@ bool TaskQueuePortImpl::DrainOneItem(
             status.MayRunLong();
         }
 
-        entry.callback(entry.callbackContext, IsCallCanceled(entry));
+        bool canceled = IsCallCanceled(entry);
+        TRACE("dispatching id %llu callback %p context %p canceled %d port %p\n",
+              (unsigned long long)entry.id, entry.callback, entry.callbackContext,
+              (int)canceled, entry.portContext);
+        entry.callback(entry.callbackContext, canceled);
         m_processingCallback--;
         m_processingCallbackCv.notify_all();
 
@@ -1851,6 +1915,8 @@ BOOLEAN XTaskQueueDispatch(
 void XTaskQueueCloseHandle(
     XTaskQueueHandle queue
 ) {
+    TRACE("queue %p\n", queue);
+
     ITaskQueue* aq = GetQueue(queue);
 
     if (aq != nullptr)
@@ -1873,6 +1939,7 @@ HRESULT XTaskQueueTerminate(
     XTaskQueueTerminatedCallback* callback
 ) {
     referenced_ptr<ITaskQueue> aq(GetQueue(queue));
+    RETURN_HR_IF(E_GAMERUNTIME_INVALID_HANDLE, aq == nullptr);
     return aq->Terminate(wait, callbackContext, callback);
 }
 
@@ -1995,36 +2062,7 @@ bool XTaskQueueGetCurrentProcessTaskQueueWithOptions(
 ) {
     *queue = nullptr;
 
-    XTaskQueueHandle processQueue = ProcessGlobals::g_processQueue;
-    if (processQueue == ProcessGlobals::g_invalidQueueHandle)
-    {
-        XTaskQueueHandle defaultProcessQueue = ProcessGlobals::g_defaultProcessQueue;
-        if (defaultProcessQueue == ProcessGlobals::g_invalidQueueHandle)
-        {
-            referenced_ptr<TaskQueueImpl> aq(new (std::nothrow) TaskQueueImpl);
-            if (aq != nullptr && SUCCEEDED(aq->Initialize(
-                XTaskQueueDispatchMode::ThreadPool,
-                XTaskQueueDispatchMode::ThreadPool)))
-            {
-                XTaskQueueHandle expected = ProcessGlobals::g_invalidQueueHandle;
-                if (ProcessGlobals::g_defaultProcessQueue.compare_exchange_strong(
-                    expected,
-                    aq->GetHandle()))
-                {
-                    aq.release();
-                }
-            }
-
-            defaultProcessQueue = ProcessGlobals::g_defaultProcessQueue;
-        }
-
-        processQueue = defaultProcessQueue;
-    }
-
-    if (processQueue == ProcessGlobals::g_invalidQueueHandle)
-    {
-        processQueue = nullptr;
-    }
+    XTaskQueueHandle processQueue = GetProcessTaskQueueHandle();
 
     if (processQueue != nullptr)
     {
@@ -2045,7 +2083,10 @@ BOOLEAN XTaskQueueGetCurrentProcessTaskQueue(
 void XTaskQueueSetCurrentProcessTaskQueue(
     XTaskQueueHandle queue
 ) {
-    XTaskQueueHandle newQueue = nullptr;
+    /* "Not set" is the invalid-handle sentinel, not null: clearing the process queue
+     * has to restore that state, otherwise the getter sees a plain null, skips
+     * creating the default process queue and hands the caller a null handle. */
+    XTaskQueueHandle newQueue = ProcessGlobals::g_invalidQueueHandle;
 
     if (queue != nullptr)
     {

--- a/dlls/xgameruntime/GDKComponent/System/Threading/XTaskQueue.h
+++ b/dlls/xgameruntime/GDKComponent/System/Threading/XTaskQueue.h
@@ -269,7 +269,7 @@ private:
 };
 
 
-class TaskQueuePortImpl : public ITaskQueuePort
+class DECLSPEC_UUID("4529CADF-1BA0-4038-A854-2C0CA26396CB") TaskQueuePortImpl : public ITaskQueuePort
 {
 public:
 
@@ -458,7 +458,7 @@ private:
 __CRT_UUID_DECL(TaskQueuePortImpl, 0x4529CADF, 0x1BA0, 0x4038, 0xA8,0x54, 0x2C,0x0C,0xA2,0x63,0x96,0xCB)
 #endif
 
-class TaskQueuePortContextImpl : public ITaskQueuePortContext
+class DECLSPEC_UUID("AFAF0302-AEBB-491A-946F-BFB283496E7A") TaskQueuePortContextImpl : public ITaskQueuePortContext
 {
 public:
 
@@ -504,7 +504,7 @@ private:
 __CRT_UUID_DECL(TaskQueuePortContextImpl, 0xAFAF0302, 0xAEBB, 0x491A, 0x94,0x6F, 0xBF,0xB2,0x83,0x49,0x6E,0x7A)
 #endif
 
-class TaskQueueImpl : public ITaskQueue
+class DECLSPEC_UUID("D63140D8-9A27-4951-B446-FB8639490A9B") TaskQueueImpl : public ITaskQueue
 #ifdef SUSPEND_API
     , public ISuspendResumeCallback
 #endif

--- a/dlls/xgameruntime/GDKComponent/System/User/UserImpl.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/User/UserImpl.cpp
@@ -24,6 +24,7 @@
 #include "../../../WineCoreUAP/Foundation/IWineAsync.hpp"
 
 #include <memory>
+#include <mutex>
 
 WINE_DEFAULT_DEBUG_CHANNEL(xodus);
 
@@ -32,6 +33,61 @@ using namespace ABI::Xodus;
 UserImpl::UserImpl( HSTRING token )
 {
     WindowsDuplicateString( token, &m_token );
+}
+
+UserImpl::UserImpl( HSTRING token, HSTRING xuid, HSTRING gamertag, HSTRING xstsToken )
+{
+    UINT32 length = 0;
+    LPCWSTR raw;
+
+    WindowsDuplicateString( token, &m_token );
+    WindowsDuplicateString( gamertag, &m_gamertag );
+    WindowsDuplicateString( xstsToken, &m_xstsToken );
+
+    /* The XUID arrives as a decimal string; callers want it as a number. */
+    raw = WindowsGetStringRawBuffer( xuid, &length );
+    if ( raw && length )
+        m_xuid = _wcstoui64( raw, nullptr, 10 );
+}
+
+UINT64 WINAPI
+UserImpl::GetXuid()
+{
+    TRACE( "iface %p\n", this );
+    return m_xuid;
+}
+
+HRESULT WINAPI
+UserImpl::GetGamertag( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( m_gamertag, out );
+    return S_OK;
+}
+
+HRESULT WINAPI
+UserImpl::GetXstsToken( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( m_xstsToken, out );
+    return S_OK;
+}
+
+HRESULT WINAPI
+UserImpl::GetPlayfabToken( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( m_playfabToken, out );
+    return S_OK;
+}
+
+void WINAPI
+UserImpl::SetPlayfabToken( HSTRING token )
+{
+    TRACE( "iface %p, token %s\n", this, debugstr_hstring( token ) );
+    WindowsDeleteString( m_playfabToken );
+    m_playfabToken = nullptr;
+    WindowsDuplicateString( token, &m_playfabToken );
 }
 
 HRESULT WINAPI
@@ -87,16 +143,25 @@ UserImpl::GetMsaToken( HSTRING *out )
     return S_OK;
 }
 
+/* The signed-in user is the same for the whole session, and callers ask for it
+ * repeatedly. Fetching a fresh MSA token every time serializes those calls behind
+ * a multi-second round trip, so keep the first one. */
+static std::mutex g_defaultUserLock;
+static XUser *g_defaultUser;
+
 static HRESULT WINAPI 
 XUserAddProvider( XAsyncOp op, const XAsyncProviderData *data )
 {
     struct XUserAddContext *context;
-    XUser user = { .m_signature = X_USER_SIGNATURE };
+    XUser *user;
 
     IXThreadingImpl *xthreading;
     HRESULT hr;
     HSTRING msaAppIdStr;
     HSTRING msaToken;
+    HSTRING xuid = nullptr;
+    HSTRING gamertag = nullptr;
+    HSTRING xstsToken = nullptr;
     LPWSTR msaAppIdW; 
     DWORD async;
     INT32 msaAppIdLen;
@@ -122,7 +187,10 @@ XUserAddProvider( XAsyncOp op, const XAsyncProviderData *data )
         case XAsyncOp::DoWork:
 #if XODUS_INTEROP
             {
-                if ( static_cast<UINT32>(context->options) & static_cast<UINT32>(XUserAddOptions::AddDefaultUserSilently) ||
+                /* None (0) asks for the account picker, which xodus has no UI for -
+                 * there is a single signed-in user, so serve it like a silent add. */
+                if ( context->options == XUserAddOptions::None ||
+                     static_cast<UINT32>(context->options) & static_cast<UINT32>(XUserAddOptions::AddDefaultUserSilently) ||
                      static_cast<UINT32>(context->options) & static_cast<UINT32>(XUserAddOptions::AddDefaultUserAllowingUI ) )
                 {
                     msaAppIdLen = MultiByteToWideChar( CP_UTF8, 0, msaAppId, -1, NULL, 0 );
@@ -148,6 +216,17 @@ XUserAddProvider( XAsyncOp op, const XAsyncProviderData *data )
                     if ( FAILED( hr ) ) 
                         goto _FALLBACK;
 
+                    {
+                        std::lock_guard<std::mutex> cached( g_defaultUserLock );
+                        if ( g_defaultUser )
+                        {
+                            TRACE( "reusing the signed-in user %p.\n", g_defaultUser );
+                            context->user = g_defaultUser;
+                            hr = S_OK;
+                            goto _COMPLETE;
+                        }
+                    }
+
                     if ( FAILED( hr = xodus_service->MsaTokenRequest( msaAppIdStr, static_cast<UINT32>(context->options) & static_cast<UINT32>(XUserAddOptions::AddDefaultUserAllowingUI), fullTrust, &token_operation ) ) ) 
                         goto _FALLBACK;
                     context->userAddEvent = CreateEventW( nullptr, FALSE, FALSE, nullptr );
@@ -166,11 +245,63 @@ XUserAddProvider( XAsyncOp op, const XAsyncProviderData *data )
                         if ( FAILED( hr ) )
                             goto _FALLBACK;
                         token_response->get_Token( &msaToken );
-                        user.m_user = new UserImpl( msaToken );
+                        token_response->get_Xuid( &xuid );
+                        token_response->get_Gamertag( &gamertag );
+                        token_response->get_XstsToken( &xstsToken );
+
+                        /* The handle outlives this call, so it cannot live on the stack. */
+                        user = new (std::nothrow) XUser;
+                        if ( !user )
+                        {
+                            WindowsDeleteString( msaToken );
+                            token_response->Release();
+                            hr = E_OUTOFMEMORY;
+                            goto _FALLBACK;
+                        }
+                        user->m_signature = X_USER_SIGNATURE;
+                        user->m_user = new UserImpl( msaToken, xuid, gamertag, xstsToken );
+                        {
+                            std::lock_guard<std::mutex> cached( g_defaultUserLock );
+                            if ( !g_defaultUser ) g_defaultUser = user;
+                        }
+
+                        /* Titles authenticate to PlayFab against its own relying
+                         * party, so settle that token here too rather than at the
+                         * first request. */
+                        {
+                            HSTRING playfabParty;
+                            IAsyncOperation<IMsaTokenResponse *> *playfab_op = nullptr;
+                            IMsaTokenResponse *playfab_response = nullptr;
+                            HSTRING playfabToken = nullptr;
+
+                            if ( SUCCEEDED( WindowsCreateString( L"http://playfab.xboxlive.com/",
+                                                                 lstrlenW( L"http://playfab.xboxlive.com/" ),
+                                                                 &playfabParty ) ) )
+                            {
+                                if ( SUCCEEDED( xodus_service->XstsTokenRequest( msaAppIdStr, playfabParty, &playfab_op ) ) &&
+                                     !AsyncOperationCompletedHandler<IMsaTokenResponse *>::await_AsyncOperation( playfab_op, INFINITE ) &&
+                                     SUCCEEDED( playfab_op->GetResults( &playfab_response ) ) &&
+                                     playfab_response )
+                                {
+                                    playfab_response->get_XstsToken( &playfabToken );
+                                    user->m_user->SetPlayfabToken( playfabToken );
+                                    WindowsDeleteString( playfabToken );
+                                    playfab_response->Release();
+                                }
+                                else
+                                {
+                                    WARN( "No PlayFab token; that sign-in will fail.\n" );
+                                }
+                                WindowsDeleteString( playfabParty );
+                            }
+                        }
                         WindowsDeleteString( msaToken );
+                        WindowsDeleteString( xuid );
+                        WindowsDeleteString( gamertag );
+                        WindowsDeleteString( xstsToken );
                         token_response->Release();
 
-                        context->user = &user;
+                        context->user = user;
                     }
                 }
                 else 
@@ -184,7 +315,9 @@ XUserAddProvider( XAsyncOp op, const XAsyncProviderData *data )
 #endif
         _COMPLETE:
             xthreading->XAsyncComplete( data->async, hr, SUCCEEDED(hr) ? sizeof(XUserHandle) : 0 );
-            hr = S_OK;
+            /* Completed here; returning success would make the framework complete
+             * the operation a second time. */
+            hr = E_PENDING;
             break;
 
         case XAsyncOp::Cleanup:
@@ -222,11 +355,32 @@ HRESULT XUserAddAsync(
 
     context->options = options;
     // ownership of context is handed to XUserAddProvider.
-    //hr = xthreading->XAsyncBegin( async, context.get(), nullptr, __func__, XUserAddProvider );
+    hr = xthreading->XAsyncBegin( async, context.get(), (void *)XUserAddProvider, __func__, XUserAddProvider );
     if ( SUCCEEDED( hr ) )
     {
         context.release();
     }
+
+    return hr;
+}
+
+HRESULT XUserAddResult(
+    XAsyncBlock *async,
+    XUserHandle *newUser
+) {
+    IXThreadingImpl *xthreading = nullptr;
+    HRESULT hr;
+
+    if ( !async || !newUser )
+        return E_POINTER;
+
+    hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading );
+    if ( FAILED( hr ) ) return hr;
+
+    /* The identity has to match the one XUserAddAsync began the operation with. */
+    hr = xthreading->XAsyncGetResult( async, (void *)XUserAddProvider,
+                                      sizeof(*newUser), newUser, nullptr );
+    xthreading->Release();
 
     return hr;
 }

--- a/dlls/xgameruntime/GDKComponent/System/User/UserImpl.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/User/UserImpl.cpp
@@ -90,6 +90,98 @@ UserImpl::SetPlayfabToken( HSTRING token )
     WindowsDuplicateString( token, &m_playfabToken );
 }
 
+/* scheme://host, dropping any path - a relying party is registered per host, and
+ * caching at that granularity keeps one exchange per back end instead of one per
+ * request. */
+static std::wstring service_key( LPCWSTR url, UINT32 length )
+{
+    std::wstring key( url, length );
+    size_t scheme = key.find( L"://" );
+    size_t slash = key.find( L'/', scheme == std::wstring::npos ? 0 : scheme + 3 );
+
+    if ( slash != std::wstring::npos ) key.erase( slash );
+    return key;
+}
+
+HRESULT WINAPI
+UserImpl::GetServiceToken( HSTRING url, HSTRING *out )
+{
+    IAsyncOperation<IMsaTokenResponse *> *operation = nullptr;
+    IMsaTokenResponse *response = nullptr;
+    HSTRING token = nullptr;
+    HSTRING clientId = nullptr;
+    LPWSTR clientIdW;
+    INT32 clientIdLen;
+    UINT32 length = 0;
+    LPCWSTR raw;
+
+    TRACE( "iface %p, url %s, out %p\n", this, debugstr_hstring( url ), out );
+
+    if ( !out ) return E_POINTER;
+    *out = nullptr;
+
+    raw = WindowsGetStringRawBuffer( url, &length );
+    if ( !raw || !length ) return E_INVALIDARG;
+
+    std::wstring key = service_key( raw, length );
+
+    {
+        std::lock_guard<std::mutex> guard( m_serviceTokensLock );
+        auto cached = m_serviceTokens.find( key );
+        if ( cached != m_serviceTokens.end() )
+            return WindowsDuplicateString( cached->second, out );
+    }
+
+    if ( !msaAppId ) return E_UNEXPECTED;
+    clientIdLen = MultiByteToWideChar( CP_UTF8, 0, msaAppId, -1, nullptr, 0 );
+    if ( !clientIdLen ) return HRESULT_FROM_WIN32( GetLastError() );
+    clientIdW = (LPWSTR)CoTaskMemAlloc( clientIdLen * sizeof(WCHAR) );
+    if ( !clientIdW ) return E_OUTOFMEMORY;
+    MultiByteToWideChar( CP_UTF8, 0, msaAppId, -1, clientIdW, clientIdLen );
+    HRESULT hr = WindowsCreateString( clientIdW, lstrlenW( clientIdW ), &clientId );
+    CoTaskMemFree( clientIdW );
+    if ( FAILED( hr ) ) return hr;
+
+    /* The service takes the request URL where a relying party goes and resolves it
+     * through the title endpoint document, so the URL travels as-is. */
+    HSTRING party = nullptr;
+    hr = WindowsCreateString( key.c_str(), (UINT32)key.size(), &party );
+    if ( SUCCEEDED( hr ) )
+    {
+        if ( SUCCEEDED( hr = xodus_service->XstsTokenRequest( clientId, party, &operation ) ) &&
+             !AsyncOperationCompletedHandler<IMsaTokenResponse *>::await_AsyncOperation( operation, INFINITE ) &&
+             SUCCEEDED( operation->GetResults( &response ) ) && response )
+        {
+            response->get_XstsToken( &token );
+            response->Release();
+        }
+        else
+        {
+            WARN( "no token for %s; the title's back end will reject the request.\n",
+                  debugstr_hstring( party ) );
+            hr = E_FAIL;
+        }
+        WindowsDeleteString( party );
+    }
+    if ( operation ) operation->Release();
+    WindowsDeleteString( clientId );
+
+    if ( !token ) return FAILED( hr ) ? hr : E_FAIL;
+
+    {
+        std::lock_guard<std::mutex> guard( m_serviceTokensLock );
+        auto cached = m_serviceTokens.emplace( key, token );
+        if ( !cached.second )
+        {
+            /* Another thread won the race; keep its entry and drop ours. */
+            WindowsDeleteString( token );
+            token = cached.first->second;
+        }
+    }
+
+    return WindowsDuplicateString( token, out );
+}
+
 HRESULT WINAPI
 UserImpl::QueryInterface( REFIID iid, void **out ) noexcept
 {

--- a/dlls/xgameruntime/GDKComponent/System/User/UserImpl.h
+++ b/dlls/xgameruntime/GDKComponent/System/User/UserImpl.h
@@ -27,9 +27,17 @@
 
 #include <atomic>
 
-struct IUser : IUnknown
+struct DECLSPEC_UUID("5F280469-FB5A-44AA-9F14-D77C7C90A5DC") IUser : IUnknown
 {
     virtual HRESULT WINAPI GetMsaToken( HSTRING *token ) = 0;
+    /* Xbox Live identity settled alongside the MSA token. */
+    virtual UINT64 WINAPI GetXuid() = 0;
+    virtual HRESULT WINAPI GetGamertag( HSTRING *gamertag ) = 0;
+    virtual HRESULT WINAPI GetXstsToken( HSTRING *token ) = 0;
+    /* Token for the PlayFab relying party, which titles authenticate against
+     * separately from plain Xbox Live. */
+    virtual HRESULT WINAPI GetPlayfabToken( HSTRING *token ) = 0;
+    virtual void WINAPI SetPlayfabToken( HSTRING token ) = 0;
 };
 //5F280469-FB5A-44AA-9F14-D77C7C90A5DC
 #ifdef __CRT_UUID_DECL
@@ -49,11 +57,16 @@ struct XUserAddContext
     HANDLE userAddEvent;
 };
 
+/* Implemented in UserImpl.cpp; XUserImpl forwards its XUser API to these. */
+HRESULT XUserAddAsync( XUserAddOptions options, XAsyncBlock *async );
+HRESULT XUserAddResult( XAsyncBlock *async, XUserHandle *newUser );
+
 class UserImpl : 
     public IUser
 {
 public:
     UserImpl( HSTRING token );
+    UserImpl( HSTRING token, HSTRING xuid, HSTRING gamertag, HSTRING xstsToken );
     virtual ~UserImpl() = default;
 
     HRESULT WINAPI QueryInterface( REFIID iid, void **out ) noexcept override;
@@ -61,9 +74,18 @@ public:
     ULONG WINAPI Release() noexcept override;
 
     HRESULT WINAPI GetMsaToken( HSTRING *out ) override;
+    UINT64 WINAPI GetXuid() override;
+    HRESULT WINAPI GetGamertag( HSTRING *out ) override;
+    HRESULT WINAPI GetXstsToken( HSTRING *out ) override;
+    HRESULT WINAPI GetPlayfabToken( HSTRING *out ) override;
+    void WINAPI SetPlayfabToken( HSTRING token ) override;
 
 private:
     HSTRING m_token;
+    HSTRING m_gamertag = nullptr;
+    HSTRING m_xstsToken = nullptr;
+    HSTRING m_playfabToken = nullptr;
+    UINT64 m_xuid = 0;
     std::atomic_long ref{ 1 };
 };
 

--- a/dlls/xgameruntime/GDKComponent/System/User/UserImpl.h
+++ b/dlls/xgameruntime/GDKComponent/System/User/UserImpl.h
@@ -26,6 +26,9 @@
 #include "../../../private.h"
 
 #include <atomic>
+#include <map>
+#include <mutex>
+#include <string>
 
 struct DECLSPEC_UUID("5F280469-FB5A-44AA-9F14-D77C7C90A5DC") IUser : IUnknown
 {
@@ -38,6 +41,9 @@ struct DECLSPEC_UUID("5F280469-FB5A-44AA-9F14-D77C7C90A5DC") IUser : IUnknown
      * separately from plain Xbox Live. */
     virtual HRESULT WINAPI GetPlayfabToken( HSTRING *token ) = 0;
     virtual void WINAPI SetPlayfabToken( HSTRING token ) = 0;
+    /* Token for a title's own back end. The service turns the request URL into the
+     * relying party Xbox registered for it, which is not derivable here. */
+    virtual HRESULT WINAPI GetServiceToken( HSTRING url, HSTRING *token ) = 0;
 };
 //5F280469-FB5A-44AA-9F14-D77C7C90A5DC
 #ifdef __CRT_UUID_DECL
@@ -79,6 +85,7 @@ public:
     HRESULT WINAPI GetXstsToken( HSTRING *out ) override;
     HRESULT WINAPI GetPlayfabToken( HSTRING *out ) override;
     void WINAPI SetPlayfabToken( HSTRING token ) override;
+    HRESULT WINAPI GetServiceToken( HSTRING url, HSTRING *out ) override;
 
 private:
     HSTRING m_token;
@@ -86,6 +93,10 @@ private:
     HSTRING m_xstsToken = nullptr;
     HSTRING m_playfabToken = nullptr;
     UINT64 m_xuid = 0;
+    /* Keyed by the request's scheme://host, which is the granularity a relying
+     * party is registered at. */
+    std::map<std::wstring, HSTRING> m_serviceTokens;
+    std::mutex m_serviceTokensLock;
     std::atomic_long ref{ 1 };
 };
 

--- a/dlls/xgameruntime/GDKComponent/System/XNetworking.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XNetworking.cpp
@@ -26,7 +26,96 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
 
-class XNetworkingImpl : 
+/* Semi-stub for the security information query: we have no pinned certificates to
+ * report, so complete the operation with an empty XNetworkingSecurityInformation.
+ * Callers wait on the XAsyncBlock, so failing synchronously would leave it pending
+ * forever and the caller would spin. */
+static HRESULT __stdcall security_information_provider( XAsyncOp op, const XAsyncProviderData *data )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    TRACE( "op %d, data %p.\n", (int)op, data );
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    switch (op)
+    {
+        case XAsyncOp::Begin:
+            return xthreading->XAsyncSchedule( data->async, 0 );
+
+        case XAsyncOp::DoWork:
+            /* Succeed with an empty thumbprint set: nothing is pinned, so ordinary
+             * certificate validation applies. Failing here instead aborts the caller's
+             * transfer half-way through - XCurl then runs its completion routine on a
+             * handle it never attached to a multi and dereferences null. */
+            xthreading->XAsyncComplete( data->async, S_OK, sizeof(XNetworkingSecurityInformation) );
+            /* Having completed the operation ourselves, the framework must not
+             * complete it a second time - that is what E_PENDING means here. */
+            return E_PENDING;
+
+        case XAsyncOp::GetResult:
+        {
+            XNetworkingSecurityInformation *info = (XNetworkingSecurityInformation *)data->buffer;
+
+            info->enabledHttpSecurityProtocolFlags = 0;
+            info->thumbprintCount = 0;
+            info->thumbprints = nullptr;
+            return S_OK;
+        }
+
+        default:
+            break;
+    }
+
+    return S_OK;
+}
+
+/* The provider address doubles as the async identity, so the ANSI and UTF-16
+ * entry points share one implementation. */
+static HRESULT begin_security_information_query( XAsyncBlock *asyncBlock )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    return xthreading->XAsyncBegin( asyncBlock, nullptr, (void *)security_information_provider,
+                                    "XNetworkingQuerySecurityInformationForUrl",
+                                    security_information_provider );
+}
+
+static HRESULT security_information_result_size( XAsyncBlock *asyncBlock, SIZE_T *byteCount )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    return xthreading->XAsyncGetResultSize( asyncBlock, byteCount );
+}
+
+static HRESULT security_information_result( XAsyncBlock *asyncBlock, SIZE_T byteCount, SIZE_T *byteCountUsed,
+                                            UINT8 *buffer, XNetworkingSecurityInformation **securityInformation )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    hr = xthreading->XAsyncGetResult( asyncBlock, (void *)security_information_provider,
+                                      byteCount, buffer, byteCountUsed );
+    if ( SUCCEEDED( hr ) && securityInformation )
+        *securityInformation = (XNetworkingSecurityInformation *)buffer;
+
+    return hr;
+}
+
+class XNetworkingImpl :
     public IXNetworkingImpl
 {
 public:
@@ -108,38 +197,42 @@ public:
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlAsync( LPCSTR url, XAsyncBlock *asyncBlock ) override
     {
-        FIXME( "url %p, asyncBlock %p stub!\n", url, asyncBlock );
-        return E_NOTIMPL;
+        FIXME( "url %p, asyncBlock %p semi-stub.\n", url, asyncBlock );
+        return begin_security_information_query( asyncBlock );
     }
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlAsyncResultSize( XAsyncBlock *asyncBlock, SIZE_T *securityInformationBufferByteCount ) override
     {
-        FIXME( "asyncBlock %p, securityInformationBufferByteCount %p stub!\n", asyncBlock, securityInformationBufferByteCount );
-        return E_NOTIMPL;
+        TRACE( "asyncBlock %p, securityInformationBufferByteCount %p.\n", asyncBlock, securityInformationBufferByteCount );
+        return security_information_result_size( asyncBlock, securityInformationBufferByteCount );
     }
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlAsyncResult( XAsyncBlock *asyncBlock, SIZE_T securityInformationBufferByteCount, SIZE_T *securityInformationBufferByteCountUsed, UINT8 *securityInformationBuffer, XNetworkingSecurityInformation **securityInformation ) override
     {
-        FIXME( "asyncBlock %p, securityInformationBufferByteCount %lld, securityInformationBufferByteCountUsed %p, securityInformationBuffer %p, securityInformation %p stub!\n", asyncBlock, securityInformationBufferByteCount, securityInformationBufferByteCountUsed, securityInformationBuffer, securityInformation );
-        return E_NOTIMPL;
+        TRACE( "asyncBlock %p, securityInformationBufferByteCount %lld, securityInformationBufferByteCountUsed %p, securityInformationBuffer %p, securityInformation %p\n", asyncBlock, securityInformationBufferByteCount, securityInformationBufferByteCountUsed, securityInformationBuffer, securityInformation );
+        return security_information_result( asyncBlock, securityInformationBufferByteCount,
+                                            securityInformationBufferByteCountUsed,
+                                            securityInformationBuffer, securityInformation );
     }
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlUtf16Async( LPCWSTR url, XAsyncBlock *asyncBlock ) override
     {
-        FIXME( "url %p, asyncBlock %p stub!\n", url, asyncBlock );
-        return E_NOTIMPL;
+        FIXME( "url %p, asyncBlock %p semi-stub.\n", url, asyncBlock );
+        return begin_security_information_query( asyncBlock );
     }
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlUtf16AsyncResultSize( XAsyncBlock *asyncBlock, SIZE_T *securityInformationBufferByteCount ) override
     {
-        FIXME( "asyncBlock %p, securityInformationBufferByteCount %p stub!\n", asyncBlock, securityInformationBufferByteCount );
-        return E_NOTIMPL;
+        TRACE( "asyncBlock %p, securityInformationBufferByteCount %p.\n", asyncBlock, securityInformationBufferByteCount );
+        return security_information_result_size( asyncBlock, securityInformationBufferByteCount );
     }
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlUtf16AsyncResult( XAsyncBlock *asyncBlock, SIZE_T securityInformationBufferByteCount, SIZE_T *securityInformationBufferByteCountUsed, UINT8 *securityInformationBuffer, XNetworkingSecurityInformation **securityInformation ) override
     {
-        TRACE( "asyncBlock %p, securityInformationBufferByteCount %lld, securityInformationBufferByteCountUsed %p, securityInformationBuffer %p, securityInformation %p stub!\n", asyncBlock, securityInformationBufferByteCount, securityInformationBufferByteCountUsed, securityInformationBuffer, securityInformation );
-        return E_NOTIMPL;
+        TRACE( "asyncBlock %p, securityInformationBufferByteCount %lld, securityInformationBufferByteCountUsed %p, securityInformationBuffer %p, securityInformation %p\n", asyncBlock, securityInformationBufferByteCount, securityInformationBufferByteCountUsed, securityInformationBuffer, securityInformation );
+        return security_information_result( asyncBlock, securityInformationBufferByteCount,
+                                            securityInformationBufferByteCountUsed,
+                                            securityInformationBuffer, securityInformation );
     }
 
     HRESULT WINAPI XNetworkingVerifyServerCertificate( PVOID requestHandle, const XNetworkingSecurityInformation *securityInformation ) override
@@ -170,20 +263,30 @@ public:
     HRESULT WINAPI XNetworkingRegisterConnectivityHintChanged( XTaskQueueHandle queue, PVOID context, XNetworkingConnectivityHintChangedCallback *callback, XTaskQueueRegistrationToken *token ) override
     {
         XNetworkingConnectivityHint hint;
-        FIXME( "queue %p, context %p, callback %p, token %p stub!\n", queue, context, callback, token );
-        XNetworkingGetConnectivityHint( &hint );
-        callback( context, &hint );
+
+        FIXME( "queue %p, context %p, callback %p semi-stub: connectivity never changes.\n", queue, context, callback );
+
+        /* The caller keeps this token and unregisters with it later, so it has to be
+         * written even though no further change will ever be reported. */
+        if ( token ) token->token = ++m_NextHintToken;
+
+        if ( callback )
+        {
+            XNetworkingGetConnectivityHint( &hint );
+            callback( context, &hint );
+        }
         return S_OK;
     }
 
     BOOLEAN WINAPI XNetworkingUnregisterConnectivityHintChanged( XTaskQueueRegistrationToken token, BOOLEAN wait ) override
     {
-        FIXME( "token %p, wait %d stub!\n", &token, wait );
-        return FALSE;
+        TRACE( "token %llu, wait %d.\n", (UINT64)token.token, wait );
+        return TRUE;
     }
 
 private:
     std::atomic_long ref{ 1 };
+    std::atomic<UINT64> m_NextHintToken{ 0 };
 };
 
 static XNetworkingImpl g_x_networking;

--- a/dlls/xgameruntime/GDKComponent/System/XNetworking.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XNetworking.cpp
@@ -197,7 +197,7 @@ public:
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlAsync( LPCSTR url, XAsyncBlock *asyncBlock ) override
     {
-        FIXME( "url %p, asyncBlock %p semi-stub.\n", url, asyncBlock );
+        FIXME( "url %s, asyncBlock %p semi-stub.\n", debugstr_a( url ), asyncBlock );
         return begin_security_information_query( asyncBlock );
     }
 
@@ -217,7 +217,7 @@ public:
 
     HRESULT WINAPI XNetworkingQuerySecurityInformationForUrlUtf16Async( LPCWSTR url, XAsyncBlock *asyncBlock ) override
     {
-        FIXME( "url %p, asyncBlock %p semi-stub.\n", url, asyncBlock );
+        FIXME( "url %s, asyncBlock %p semi-stub.\n", debugstr_w( url ), asyncBlock );
         return begin_security_information_query( asyncBlock );
     }
 

--- a/dlls/xgameruntime/GDKComponent/System/XStore.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XStore.cpp
@@ -1,0 +1,554 @@
+/*
+ * Xbox Game runtime Library
+ *  GDK Component: System API -> XStore
+ *
+ * Copyright 2026 Olivia Ryan
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "private.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
+
+class XStoreImpl : public IXStoreImpl6
+{
+public:
+    HRESULT WINAPI QueryInterface( REFIID iid, void **out ) override
+    {
+        TRACE( "iface %p, iid %s, out %p.\n", this, debugstr_guid( &iid ), out );
+
+        if (iid == __uuidof( IUnknown     ) ||
+            iid == __uuidof( IXStoreImpl  ) ||
+            iid == __uuidof( IXStoreImpl2 ) ||
+            iid == __uuidof( IXStoreImpl3 ) ||
+            iid == __uuidof( IXStoreImpl4 ) ||
+            iid == __uuidof( IXStoreImpl5 ) ||
+            iid == __uuidof( IXStoreImpl6 ))
+        {
+            AddRef();
+            *out = static_cast<IXStoreImpl6 *>(this);
+            return S_OK;
+        }
+
+        FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( &iid ) );
+        *out = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG WINAPI AddRef() override
+    {
+        ULONG ref = InterlockedIncrement( &this->ref );
+        TRACE( "iface %p increasing refcount to %lu.\n", this, ref );
+        return ref;
+    }
+
+    ULONG WINAPI Release() override
+    {
+        ULONG ref = InterlockedDecrement( &this->ref );
+        TRACE( "iface %p decreasing refcount to %lu.\n", this, ref );
+        return ref;
+    }
+
+    HRESULT WINAPI XStoreCreateContext( const XUserHandle user, XStoreContextHandle *storeContextHandle ) override
+    {
+        FIXME( "iface %p, user %p, storeContextHandle %p stub!\n", this, user, storeContextHandle );
+        return E_NOTIMPL;
+    }
+
+    void WINAPI XStoreCloseContextHandle( XStoreContextHandle storeContextHandle ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p stub!\n", this, storeContextHandle );
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage %u, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, const char **storeIds, SIZE_T storeIdsCount, const char **actionFilters, SIZE_T actionFiltersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, storeIds %p, storeIdsCount %Iu, actionFilters %p, actionFiltersCount %Iu, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), storeIds, storeIdsCount, actionFilters, actionFiltersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryEntitledProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage, %u, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryEntitledProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForCurrentGameAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForCurrentGameResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForPackageAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, packageIdentifier %s, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryProductForPackageResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreEnumerateProductsQuery( const XStoreProductQueryHandle productQueryHandle, void *context, XStoreProductQueryCallback *callback ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, context %p, callback %p stub!\n", this, productQueryHandle, context, callback );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreProductsQueryHasMorePages( const XStoreProductQueryHandle productQueryHandle ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p stub!\n", this, productQueryHandle );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreProductsQueryNextPageAsync( const XStoreProductQueryHandle productQueryHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, async %p stub!\n", this, productQueryHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreProductsQueryNextPageResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    void WINAPI XStoreCloseProductsQueryHandle( XStoreProductQueryHandle productQueryHandle ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p stub!\n", this, productQueryHandle );
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForPackageAsync( const XStoreProductQueryHandle productQueryHandle, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, productQueryHandle %p, packageIdentifier %s, async %p stub!\n", this, productQueryHandle, debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForPackageResult( XAsyncBlock *async, XStoreLicenseHandle *storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, async %p, storeLicenseHandle %p stub!\n", this, async, storeLicenseHandle );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreIsLicenseValid( const XStoreLicenseHandle storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p stub!\n", this, storeLicenseHandle );
+        return FALSE;
+    }
+
+    void WINAPI XStoreCloseLicenseHandle( XStoreLicenseHandle storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p stub!\n", this, storeLicenseHandle );
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForStoreIdAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForStoreIdResult( XAsyncBlock *async, XStoreCanAcquireLicenseResult *storeCanAcquireLicense ) override
+    {
+        FIXME( "iface %p, async %p, storeCanAcquireLicense %p stub!\n", this, async, storeCanAcquireLicense );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForPackageAsync( const XStoreContextHandle storeContextHandle, const char *packageIdentifier, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifier %s, async %p stub!\n", this, storeContextHandle, debugstr_a( packageIdentifier ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreCanAcquireLicenseForPackageResult( XAsyncBlock *async, XStoreCanAcquireLicenseResult *storeCanAcquireLicense ) override
+    {
+        FIXME( "iface %p, async %p, storeCanAcquireLicense %p stub!\n", this, async, storeCanAcquireLicense );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameLicenseAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameLicenseResult( XAsyncBlock *async, XStoreGameLicense *license ) override
+    {
+        FIXME( "iface %p, async %p, license %p stub!\n", this, async, license );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAddOnLicensesResult( XAsyncBlock *async, UINT32 count, XStoreAddonLicense *addOnLicenses ) override
+    {
+        FIXME( "iface %p, async %p, count %u, addOnLicenses %p stub!\n", this, async, count, addOnLicenses );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryConsumableBalanceRemainingAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryConsumableBalanceRemainingResult( XAsyncBlock *async, XStoreConsumableResult *consumableResult ) override
+    {
+        FIXME( "iface %p, async %p, consumableResult %p stub!\n", this, async, consumableResult );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreReportConsumableFulfillmentAsync( const XStoreContextHandle storeContextHandle, const char *storeProductId, UINT32 quantity, GUID trackingId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeProductId %s, quantity %u, trackingId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeProductId ), quantity, debugstr_guid( &trackingId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreReportConsumableFulfillmentResult( XAsyncBlock *async, XStoreConsumableResult *consumableResult ) override
+    {
+        FIXME( "iface %p, async %p, consumableResult %p stub!\n", this, async, consumableResult );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdAsync( const XStoreContextHandle storeContextHandle, const char *serviceTicket, const char *publisherUserId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, serviceTicket %s, userId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( serviceTicket ), debugstr_a( publisherUserId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserCollectionsIdResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdAsync( const XStoreContextHandle storeContextHandle, const char *serviceTicket, const char *publisherUserId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, serviceTicket %s, publisherUserId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( serviceTicket ), debugstr_a( publisherUserId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreGetUserPurchaseIdResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenAsync( const XStoreContextHandle storeContextHandle, const char **productIds, SIZE_T productIdsCount, const char *customDeveloperString, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, productIdsCount %p, idsCount %Iu, custom %s, async %p stub!\n", this, storeContextHandle, productIds, productIdsCount, debugstr_a( customDeveloperString ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenResultSize( XAsyncBlock *async, SIZE_T *size ) override
+    {
+        FIXME( "iface %p, async %p, size %p stub!\n", this, async, size );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryLicenseTokenResult( XAsyncBlock *async, SIZE_T size, char *result ) override
+    {
+        FIXME( "iface %p, async %p, size %Iu, result %p stub!\n", this, async, size, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING_2__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI __PADDING_3__() override
+    {
+        WARN( "iface %p padding function called! It's unknown what this function does.\n", this );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowPurchaseUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, const char *name, const char *extendedJsonData, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, name %s, extendedJsonData %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), debugstr_a( name ), debugstr_a( extendedJsonData ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowPurchaseUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRateAndReviewUIAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRateAndReviewUIResult( XAsyncBlock *async, XStoreRateAndReviewResult *result ) override
+    {
+        FIXME( "iface %p, async %p, result %p stub!\n", this, async, result );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRedeemTokenUIAsync( const XStoreContextHandle storeContextHandle, const char *token, const char **allowedStoreIds, SIZE_T allowedStoreIdsCount, BOOLEAN disallowCsvRedemption, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, token %s, allowedStoreIds %p, allowedStoreIdsCount %Iu, disallowCsvRedemption %d, async %p stub!\n", this, storeContextHandle, debugstr_a( token ), allowedStoreIds, allowedStoreIdsCount, disallowCsvRedemption, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowRedeemTokenUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryGameAndDlcPackageUpdatesResult( XAsyncBlock *async, UINT32 count, XStorePackageUpdate *packageUpdates ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageUpdates %p stub!\n", this, async, count, packageUpdates );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadPackageUpdatesAsync( XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadPackageUpdatesResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackageUpdatesAsync( const XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackageUpdatesResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesAsync( const XStoreContextHandle storeContextHandle, const char **storeIds, SIZE_T storeIdsCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeIds %p, storeIdsCount %Iu, async %p stub!\n", this, storeContextHandle, storeIds, storeIdsCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreDownloadAndInstallPackagesResult( XAsyncBlock *async, UINT32 count, char **packageIdentifiers ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageIdentifiers %p stub!\n", this, async, count, packageIdentifiers );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageIdentifier( const char *storeId, SIZE_T size, char *packageIdentifier ) override
+    {
+        FIXME( "iface %p, storeId %s, size %Iu, packageIdentifier %p stub!\n", this, debugstr_a( storeId ), size, packageIdentifier );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreRegisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueHandle queue, void *context, XStoreGameLicenseChangedCallback *callback, XTaskQueueRegistrationToken *token ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, queue %p, context %p, callback %p, token %p stub!\n", this, storeContextHandle, queue, context, callback, token );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreUnregisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, token %p, wait %d stub!\n", this, storeContextHandle, &token, wait );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreRegisterPackageLicenseLost( XStoreLicenseHandle storeLicenseHandle, XTaskQueueHandle queue, void *context, XStorePackageLicenseLostCallback *callback, XTaskQueueRegistrationToken *token) override
+    {
+        FIXME( "iface %p, storeLicenseHandle %p, queue %p, context %p, callback %p, token %p stub!\n", this, storeLicenseHandle, queue, context, callback, token );
+        return E_NOTIMPL;
+    }
+
+    BOOLEAN WINAPI XStoreUnregisterPackageLicenseLost( XStoreLicenseHandle licenseHandle, XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        FIXME( "iface %p, licenseHandle %p, token %p, wait %d stub!\n", this, licenseHandle, &token, wait );
+        return FALSE;
+    }
+
+    BOOLEAN WINAPI XStoreIsAvailabilityPurchasable( const XStoreAvailability availability ) override
+    {
+        FIXME( "iface %p, availability %p stub!\n", this, &availability );
+        return FALSE;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForDurablesAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreAcquireLicenseForDurablesResult( XAsyncBlock *async, XStoreLicenseHandle *storeLicenseHandle ) override
+    {
+        FIXME( "iface %p, async %p, storeLicenseHandle %p stub!\n", this, async, storeLicenseHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowAssociatedProductsUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XStoreProductKind productKinds, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, productKinds %#x, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), static_cast<UINT32>(productKinds), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowAssociatedProductsUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowProductPageUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowProductPageUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsForStoreIdAsync( const XStoreContextHandle storeContextHandle, const char *storeId, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, productKinds %#x, maxItemsToRetrievePerPage %u, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryAssociatedProductsForStoreIdResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
+    {
+        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesAsync( XStoreContextHandle storeContextHandle, const char **packageIdentifiers, SIZE_T packageIdentifiersCount, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, packageIdentifiers %p, packageIdentifiersCount %Iu, async %p stub!\n", this, storeContextHandle, packageIdentifiers, packageIdentifiersCount, async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesResultCount( XAsyncBlock *async, UINT32 *count ) override
+    {
+        FIXME( "iface %p, async %p, count %p stub!\n", this, async, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreQueryPackageUpdatesResult( XAsyncBlock *async, UINT32 count, XStorePackageUpdate *packageUpdates ) override
+    {
+        FIXME( "iface %p, async %p, count %u, packageUpdates %p stub!\n", this, async, count, packageUpdates );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowGiftingUIAsync( const XStoreContextHandle storeContextHandle, const char *storeId, const char *name, const char *extendedJsonData, XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, storeContextHandle %p, storeId %s, name %s, extendedJsonData %s, async %p stub!\n", this, storeContextHandle, debugstr_a( storeId ), debugstr_a( name ), debugstr_a( extendedJsonData ), async );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XStoreShowGiftingUIResult( XAsyncBlock *async ) override
+    {
+        FIXME( "iface %p, async %p stub!\n", this, async );
+        return E_NOTIMPL;
+    }
+
+private:
+    LONG ref = 1;
+};
+
+static XStoreImpl g_x_store;
+
+IXStoreImpl *x_store = static_cast<IXStoreImpl *>(&g_x_store);

--- a/dlls/xgameruntime/GDKComponent/System/XStore.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XStore.cpp
@@ -34,6 +34,17 @@ static HRESULT __stdcall license_query_work( XAsyncBlock * )
     return S_OK;
 }
 
+/* Marker for an empty product query. Titles hold the handle and enumerate through it,
+ * so it has to be a distinct pointer they can close, not null. */
+#define PRODUCT_QUERY_SIGNATURE 0x5850524Bu /* XPRK */
+
+static UINT32 g_empty_product_query = PRODUCT_QUERY_SIGNATURE;
+
+static HRESULT __stdcall product_query_work( XAsyncBlock * )
+{
+    return S_OK;
+}
+
 class XStoreImpl : public IXStoreImpl6
 {
 public:
@@ -101,14 +112,20 @@ public:
 
     HRESULT WINAPI XStoreQueryAssociatedProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, UINT32 maxItemsToRetrievePerPage, XAsyncBlock *async ) override
     {
-        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage %u, async %p stub!\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage, async );
-        return E_NOTIMPL;
+        FIXME( "iface %p, storeContextHandle %p, productKinds %#x, maxItemsToRetrievePerPage %u semi-stub: no add-ons.\n", this, storeContextHandle, static_cast<UINT32>(productKinds), maxItemsToRetrievePerPage );
+
+        /* There is no store catalogue behind this, but failing the call outright leaves
+         * the title without an answer; an empty product list is a definite one. */
+        return XAsyncRun( async, product_query_work );
     }
 
     HRESULT WINAPI XStoreQueryAssociatedProductsResult( XAsyncBlock *async, XStoreProductQueryHandle *productQueryHandle ) override
     {
-        FIXME( "iface %p, async %p, productQueryHandle %p stub!\n", this, async, productQueryHandle );
-        return E_NOTIMPL;
+        TRACE( "iface %p, async %p, productQueryHandle %p.\n", this, async, productQueryHandle );
+
+        if ( !productQueryHandle ) return E_POINTER;
+        *productQueryHandle = &g_empty_product_query;
+        return S_OK;
     }
 
     HRESULT WINAPI XStoreQueryProductsAsync( const XStoreContextHandle storeContextHandle, XStoreProductKind productKinds, const char **storeIds, SIZE_T storeIdsCount, const char **actionFilters, SIZE_T actionFiltersCount, XAsyncBlock *async ) override
@@ -161,8 +178,11 @@ public:
 
     HRESULT WINAPI XStoreEnumerateProductsQuery( const XStoreProductQueryHandle productQueryHandle, void *context, XStoreProductQueryCallback *callback ) override
     {
-        FIXME( "iface %p, productQueryHandle %p, context %p, callback %p stub!\n", this, productQueryHandle, context, callback );
-        return E_NOTIMPL;
+        TRACE( "iface %p, productQueryHandle %p, context %p, callback %p.\n", this, productQueryHandle, context, callback );
+
+        /* Nothing to hand back, so the callback is never invoked - that is how the
+         * enumeration reports an empty query. */
+        return S_OK;
     }
 
     BOOLEAN WINAPI XStoreProductsQueryHasMorePages( const XStoreProductQueryHandle productQueryHandle ) override
@@ -185,7 +205,7 @@ public:
 
     void WINAPI XStoreCloseProductsQueryHandle( XStoreProductQueryHandle productQueryHandle ) override
     {
-        FIXME( "iface %p, productQueryHandle %p stub!\n", this, productQueryHandle );
+        TRACE( "iface %p, productQueryHandle %p.\n", this, productQueryHandle );
     }
 
     HRESULT WINAPI XStoreAcquireLicenseForPackageAsync( const XStoreProductQueryHandle productQueryHandle, const char *packageIdentifier, XAsyncBlock *async ) override

--- a/dlls/xgameruntime/GDKComponent/System/XStore.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XStore.cpp
@@ -21,7 +21,18 @@
 
 #include "private.h"
 
+#include <new>
+#include <atomic>
+#include <cstring>
+
 WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
+
+#define STORE_CONTEXT_SIGNATURE 0x58535443 /* XSTC */
+
+static HRESULT __stdcall license_query_work( XAsyncBlock * )
+{
+    return S_OK;
+}
 
 class XStoreImpl : public IXStoreImpl6
 {
@@ -64,11 +75,26 @@ public:
 
     HRESULT WINAPI XStoreCreateContext( const XUserHandle user, XStoreContextHandle *storeContextHandle ) override
     {
-        FIXME( "iface %p, user %p, storeContextHandle %p stub!\n", this, user, storeContextHandle );
-        return E_NOTIMPL;
+        FIXME( "iface %p, user %p semi-stub: handing out an opaque context.\n", this, user );
+
+        if ( !storeContextHandle ) return E_POINTER;
+
+        /* The handle is opaque to callers and every store query is still a stub, so
+         * an owning marker is enough. Failing here instead makes callers spin. */
+        *storeContextHandle = (XStoreContextHandle)new (std::nothrow) UINT32( STORE_CONTEXT_SIGNATURE );
+        if ( !*storeContextHandle ) return E_OUTOFMEMORY;
+
+        return S_OK;
     }
 
     void WINAPI XStoreCloseContextHandle( XStoreContextHandle storeContextHandle ) override
+    {
+        TRACE( "iface %p, storeContextHandle %p.\n", this, storeContextHandle );
+        delete (UINT32 *)storeContextHandle;
+        return;
+    }
+
+    void WINAPI __XStoreCloseContextHandle_unused( XStoreContextHandle storeContextHandle )
     {
         FIXME( "iface %p, storeContextHandle %p stub!\n", this, storeContextHandle );
     }
@@ -211,14 +237,23 @@ public:
 
     HRESULT WINAPI XStoreQueryGameLicenseAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
     {
-        FIXME( "iface %p, storeContextHandle %p, async %p stub!\n", this, storeContextHandle, async );
-        return E_NOTIMPL;
+        FIXME( "iface %p, storeContextHandle %p semi-stub: reporting a full license.\n", this, storeContextHandle );
+
+        /* The entitlement was already proven when xodus fetched the package license,
+         * so report an owned, non-trial license through the async completion. */
+        return XAsyncRun( async, license_query_work );
     }
 
     HRESULT WINAPI XStoreQueryGameLicenseResult( XAsyncBlock *async, XStoreGameLicense *license ) override
     {
-        FIXME( "iface %p, async %p, license %p stub!\n", this, async, license );
-        return E_NOTIMPL;
+        TRACE( "iface %p, async %p, license %p.\n", this, async, license );
+
+        if ( !license ) return E_POINTER;
+
+        memset( license, 0, sizeof(*license) );
+        license->isActive = TRUE;
+
+        return S_OK;
     }
 
     HRESULT WINAPI XStoreQueryAddOnLicensesAsync( const XStoreContextHandle storeContextHandle, XAsyncBlock *async ) override
@@ -439,8 +474,11 @@ public:
 
     HRESULT WINAPI XStoreRegisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueHandle queue, void *context, XStoreGameLicenseChangedCallback *callback, XTaskQueueRegistrationToken *token ) override
     {
-        FIXME( "iface %p, storeContextHandle %p, queue %p, context %p, callback %p, token %p stub!\n", this, storeContextHandle, queue, context, callback, token );
-        return E_NOTIMPL;
+        FIXME( "iface %p, storeContextHandle %p, queue %p, context %p, callback %p semi-stub: the license never changes.\n",
+               this, storeContextHandle, queue, context, callback );
+
+        if ( token ) token->token = ++m_NextLicenseToken;
+        return S_OK;
     }
 
     BOOLEAN WINAPI XStoreUnregisterGameLicenseChanged( XStoreContextHandle storeContextHandle, XTaskQueueRegistrationToken token, BOOLEAN wait ) override
@@ -547,6 +585,7 @@ public:
 
 private:
     LONG ref = 1;
+    std::atomic<UINT64> m_NextLicenseToken{ 0 };
 };
 
 static XStoreImpl g_x_store;

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -25,6 +25,10 @@
 #include <cstring>
 #include <atomic>
 #include <new>
+#include <mutex>
+
+#include <bcrypt.h>
+#include <wincrypt.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
 
@@ -40,6 +44,128 @@ static HRESULT __stdcall not_implemented_async_work( XAsyncBlock * )
 #define XSTS_TOKEN_MAX 8192
 /* XUserGamertagComponentUniqueModernMaxBytes, the largest of the four components. */
 #define XUSER_GAMERTAG_MAX 64
+/* base64 of the 76 byte signature blob, plus room for the terminator. */
+#define SIGNATURE_MAX 128
+
+/* Xbox binds a token to the ECDSA P-256 key whose JWK went out as ProofKey, and
+ * verifies request signatures against it. One key per process is enough here: xodus
+ * signs in a single user. See
+ * https://learn.microsoft.com/gaming/gdk/docs/services/fundamentals/s2s-auth-calls/s2s-calls/live-title-service-calls-xbox-live#proof-keys */
+static std::once_flag g_proof_key_once;
+static BCRYPT_KEY_HANDLE g_proof_key = nullptr;
+static char g_proof_key_jwk[512];
+
+static HRESULT base64_url_no_pad( const BYTE *data, DWORD size, char *out, DWORD outSize )
+{
+    char *p;
+
+    if ( !CryptBinaryToStringA( data, size, CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF, out, &outSize ) )
+        return HRESULT_FROM_WIN32( GetLastError() );
+
+    for ( p = out; *p; p++ )
+    {
+        if ( *p == '+' ) *p = '-';
+        else if ( *p == '/' ) *p = '_';
+        else if ( *p == '=' ) { *p = '\0'; break; }
+    }
+    return S_OK;
+}
+
+static void create_proof_key()
+{
+    UCHAR blob[sizeof(BCRYPT_ECCKEY_BLOB) + 64];
+    char x[64] = {}, y[64] = {};
+    BCRYPT_ALG_HANDLE ecdsa = nullptr;
+    BCRYPT_KEY_HANDLE key = nullptr;
+    ULONG written;
+
+    if ( !BCRYPT_SUCCESS( BCryptOpenAlgorithmProvider( &ecdsa, BCRYPT_ECDSA_P256_ALGORITHM, nullptr, 0 ) ) )
+        return;
+
+    if ( BCRYPT_SUCCESS( BCryptGenerateKeyPair( ecdsa, &key, 256, 0 ) ) &&
+         BCRYPT_SUCCESS( BCryptFinalizeKeyPair( key, 0 ) ) &&
+         BCRYPT_SUCCESS( BCryptExportKey( key, nullptr, BCRYPT_ECCPUBLIC_BLOB, blob, sizeof(blob), &written, 0 ) ) &&
+         SUCCEEDED( base64_url_no_pad( blob + sizeof(BCRYPT_ECCKEY_BLOB), 32, x, sizeof(x) ) ) &&
+         SUCCEEDED( base64_url_no_pad( blob + sizeof(BCRYPT_ECCKEY_BLOB) + 32, 32, y, sizeof(y) ) ) )
+    {
+        snprintf( g_proof_key_jwk, sizeof(g_proof_key_jwk),
+                  "{\"alg\":\"ES256\",\"kty\":\"EC\",\"use\":\"sig\",\"crv\":\"P-256\",\"x\":\"%s\",\"y\":\"%s\"}",
+                  x, y );
+        g_proof_key = key;
+        key = nullptr;
+    }
+
+    if ( key ) BCryptDestroyKey( key );
+    BCryptCloseAlgorithmProvider( ecdsa, 0 );
+}
+
+EXTERN_C const char *XodusProofKeyJwk( void )
+{
+    std::call_once( g_proof_key_once, create_proof_key );
+    return g_proof_key_jwk[0] ? g_proof_key_jwk : nullptr;
+}
+
+/* The signed blob is each field NUL terminated in order: version, timestamp, method,
+ * path and query, the Authorization header, then the body. */
+static HRESULT sign_request( const char *method, const char *url, const char *authorization,
+                             const void *body, SIZE_T bodySize, char *out, DWORD outSize )
+{
+    BYTE raw[76] = {}, hash[32];
+    BCRYPT_ALG_HANDLE sha = nullptr;
+    BCRYPT_HASH_HANDLE hashObj = nullptr;
+    const char *pathAndQuery;
+    FILETIME ft;
+    ULONGLONG stamp;
+    ULONG written;
+    NTSTATUS status;
+    HRESULT hr = E_FAIL;
+    UINT32 version = 1;
+
+    std::call_once( g_proof_key_once, create_proof_key );
+    if ( !g_proof_key ) return E_FAIL;
+
+    /* Skip the scheme and host; the policy signs only the path with its query. */
+    pathAndQuery = url ? strstr( url, "://" ) : nullptr;
+    pathAndQuery = pathAndQuery ? strchr( pathAndQuery + 3, '/' ) : nullptr;
+    if ( !pathAndQuery ) pathAndQuery = "/";
+
+    GetSystemTimeAsFileTime( &ft );
+    stamp = ( (ULONGLONG)ft.dwHighDateTime << 32 ) | ft.dwLowDateTime;
+
+    raw[0] = (BYTE)(version >> 24); raw[1] = (BYTE)(version >> 16);
+    raw[2] = (BYTE)(version >> 8);  raw[3] = (BYTE)version;
+    for ( int i = 0; i < 8; i++ ) raw[4 + i] = (BYTE)( stamp >> ( 56 - i * 8 ) );
+
+    if ( !BCRYPT_SUCCESS( status = BCryptOpenAlgorithmProvider( &sha, BCRYPT_SHA256_ALGORITHM, nullptr, 0 ) ) )
+        return HRESULT_FROM_NT( status );
+
+    if ( BCRYPT_SUCCESS( BCryptCreateHash( sha, &hashObj, nullptr, 0, nullptr, 0, 0 ) ) )
+    {
+        static const BYTE nul = 0;
+        BCryptHashData( hashObj, raw, 12, 0 );
+        BCryptHashData( hashObj, (PUCHAR)&nul, 1, 0 );
+        BCryptHashData( hashObj, (PUCHAR)( method ? method : "GET" ), method ? strlen( method ) : 3, 0 );
+        BCryptHashData( hashObj, (PUCHAR)&nul, 1, 0 );
+        BCryptHashData( hashObj, (PUCHAR)pathAndQuery, strlen( pathAndQuery ), 0 );
+        BCryptHashData( hashObj, (PUCHAR)&nul, 1, 0 );
+        BCryptHashData( hashObj, (PUCHAR)( authorization ? authorization : "" ), authorization ? strlen( authorization ) : 0, 0 );
+        BCryptHashData( hashObj, (PUCHAR)&nul, 1, 0 );
+        if ( body && bodySize ) BCryptHashData( hashObj, (PUCHAR)body, (ULONG)bodySize, 0 );
+        BCryptHashData( hashObj, (PUCHAR)&nul, 1, 0 );
+
+        if ( BCRYPT_SUCCESS( BCryptFinishHash( hashObj, hash, sizeof(hash), 0 ) ) &&
+             BCRYPT_SUCCESS( BCryptSignHash( g_proof_key, nullptr, hash, sizeof(hash),
+                                             raw + 12, 64, &written, 0 ) ) )
+        {
+            hr = CryptBinaryToStringA( raw, sizeof(raw), CRYPT_STRING_BASE64 | CRYPT_STRING_NOCRLF,
+                                       out, &outSize ) ? S_OK : HRESULT_FROM_WIN32( GetLastError() );
+        }
+        BCryptDestroyHash( hashObj );
+    }
+
+    BCryptCloseAlgorithmProvider( sha, 0 );
+    return hr;
+}
 
 /* Which service the caller is authenticating to decides which stored token fits;
  * both travel to GetResult as the provider context. */
@@ -47,6 +173,10 @@ struct TokenAndSignatureContext
 {
     XUserHandle user;
     bool playfab;
+    char *method;
+    char *url;
+    void *body;
+    SIZE_T bodySize;
 };
 
 static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsyncProviderData *data )
@@ -65,7 +195,7 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
         case XAsyncOp::DoWork:
             xthreading->XAsyncComplete( data->async, S_OK,
                                         sizeof(XUserGetTokenAndSignatureData)
-                                        + XSTS_TOKEN_MAX + 1 );
+                                        + XSTS_TOKEN_MAX + 1 + SIGNATURE_MAX + 1 );
             /* Completed here, so the framework must not complete it again. */
             return E_PENDING;
 
@@ -95,18 +225,37 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
 
             token[written] = '\0';
 
-            /* No request signature: Xbox signs requests with the device key, which
-             * xodus does not hold. The token alone is what most services check. */
+            char *signature = token + written + 1;
+            signature[0] = '\0';
+            if ( written && FAILED( sign_request( ctx ? ctx->method : nullptr,
+                                                  ctx ? ctx->url : nullptr, token,
+                                                  ctx ? ctx->body : nullptr,
+                                                  ctx ? ctx->bodySize : 0,
+                                                  signature, SIGNATURE_MAX ) ) )
+            {
+                WARN( "request signature unavailable; sending the token unsigned.\n" );
+                signature[0] = '\0';
+            }
+
             result->tokenSize = written;
-            result->signatureSize = 0;
+            result->signatureSize = strlen( signature );
             result->token = token;
-            result->signature = token + written;
+            result->signature = signature;
             return S_OK;
         }
 
         case XAsyncOp::Cleanup:
-            delete (TokenAndSignatureContext *)data->context;
+        {
+            auto *ctx = (TokenAndSignatureContext *)data->context;
+            if ( ctx )
+            {
+                free( ctx->method );
+                free( ctx->url );
+                free( ctx->body );
+            }
+            delete ctx;
             break;
+        }
 
         default:
             break;
@@ -115,7 +264,13 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
     return S_OK;
 }
 
-static HRESULT begin_token_and_signature( XUserHandle user, const char *url, XAsyncBlock *async )
+static char *dup_string( const char *value )
+{
+    return value ? _strdup( value ) : nullptr;
+}
+
+static HRESULT begin_token_and_signature( XUserHandle user, const char *method, const char *url,
+                                          const void *body, SIZE_T bodySize, XAsyncBlock *async )
 {
     IXThreadingImpl *xthreading;
     HRESULT hr;
@@ -128,6 +283,13 @@ static HRESULT begin_token_and_signature( XUserHandle user, const char *url, XAs
 
     ctx->user = user;
     ctx->playfab = url && strstr( url, "playfab" ) != nullptr;
+    /* The provider runs later on a worker thread, so the request has to be copied. */
+    ctx->method = dup_string( method );
+    ctx->url = dup_string( url );
+    ctx->bodySize = body ? bodySize : 0;
+    ctx->body = nullptr;
+    if ( ctx->bodySize && (ctx->body = malloc( ctx->bodySize )) )
+        memcpy( ctx->body, body, ctx->bodySize );
 
     hr = xthreading->XAsyncBegin( async, ctx, (void *)token_and_signature_provider,
                                   "XUserGetTokenAndSignature", token_and_signature_provider );
@@ -509,7 +671,7 @@ public:
         FIXME( "user %p, options %d, method %s, url %s, headerCount %Iu, headers %p, bodySize %Iu, bodyBuffer %p, async %p stub!\n", user, (int)options, debugstr_a( method ), debugstr_a( url ), headerCount, headers, bodySize, bodyBuffer, async );
         /* The caller waits on the block; a synchronous failure leaves it pending
          * and the request is torn down half-initialized. */
-        return begin_token_and_signature( user, url, async );
+        return begin_token_and_signature( user, method, url, bodyBuffer, bodySize, async );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override
@@ -535,7 +697,13 @@ public:
         if ( url )
             WideCharToMultiByte( CP_UTF8, 0, url, -1, urlA, sizeof(urlA), nullptr, nullptr );
 
-        return begin_token_and_signature( user, urlA, async );
+        char methodA[32];
+
+        methodA[0] = '\0';
+        if ( method )
+            WideCharToMultiByte( CP_UTF8, 0, method, -1, methodA, sizeof(methodA), nullptr, nullptr );
+
+        return begin_token_and_signature( user, methodA, urlA, bodyBuffer, bodySize, async );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureUtf16ResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -236,7 +236,83 @@ struct TokenAndSignatureContext
     char *url;
     void *body;
     SIZE_T bodySize;
+    /* Resolved on the worker thread, because a title's own back end needs a token
+     * fetched for its relying party rather than one of the two settled at sign-in. */
+    char *token;
+    /* The UTF-16 entry points want the same answer in wide characters. */
+    bool utf16;
 };
+
+/* Xbox Live's own hosts all sit behind the relying party settled at sign-in; a
+ * title's back end does not, and needs its own exchange. */
+static bool is_xboxlive_host( const char *url )
+{
+    const char *host = url ? strstr( url, "://" ) : nullptr;
+    const char *end;
+    size_t len;
+
+    if ( !host ) return false;
+    host += 3;
+    end = strchr( host, '/' );
+    len = end ? (size_t)(end - host) : strlen( host );
+
+    return len >= 12 && !strncmp( host + len - 12, "xboxlive.com", 12 );
+}
+
+/* Fills ctx->token with the UTF-8 token the caller should present. Runs on the
+ * worker thread because an unseen back end costs a round trip to the service. */
+static void resolve_token( TokenAndSignatureContext *ctx )
+{
+    XUserHandle user = ctx ? ctx->user : nullptr;
+    HSTRING stored = nullptr;
+    HSTRING url = nullptr;
+    UINT32 length = 0;
+    LPCWSTR raw;
+
+    if ( !ctx || ctx->token ) return;
+    if ( !user || user->m_signature != X_USER_SIGNATURE || !user->m_user ) return;
+
+    if ( ctx->playfab )
+    {
+        if ( FAILED( user->m_user->GetPlayfabToken( &stored ) ) ) return;
+    }
+    else if ( !ctx->url || is_xboxlive_host( ctx->url ) )
+    {
+        if ( FAILED( user->m_user->GetXstsToken( &stored ) ) ) return;
+    }
+    else
+    {
+        INT32 wide = MultiByteToWideChar( CP_UTF8, 0, ctx->url, -1, nullptr, 0 );
+        LPWSTR urlW = wide ? (LPWSTR)CoTaskMemAlloc( wide * sizeof(WCHAR) ) : nullptr;
+
+        if ( !urlW ) return;
+        MultiByteToWideChar( CP_UTF8, 0, ctx->url, -1, urlW, wide );
+        HRESULT hr = WindowsCreateString( urlW, lstrlenW( urlW ), &url );
+        CoTaskMemFree( urlW );
+        if ( FAILED( hr ) ) return;
+
+        hr = user->m_user->GetServiceToken( url, &stored );
+        WindowsDeleteString( url );
+        if ( FAILED( hr ) )
+        {
+            /* Better a generic token than none - some back ends accept it. */
+            WARN( "falling back to the Xbox Live token for %s.\n", debugstr_a( ctx->url ) );
+            if ( FAILED( user->m_user->GetXstsToken( &stored ) ) ) return;
+        }
+    }
+
+    raw = WindowsGetStringRawBuffer( stored, &length );
+    if ( raw && length )
+    {
+        INT bytes = WideCharToMultiByte( CP_UTF8, 0, raw, length, nullptr, 0, nullptr, nullptr );
+        if ( bytes > 0 && (ctx->token = (char *)malloc( bytes + 1 )) )
+        {
+            WideCharToMultiByte( CP_UTF8, 0, raw, length, ctx->token, bytes, nullptr, nullptr );
+            ctx->token[bytes] = '\0';
+        }
+    }
+    WindowsDeleteString( stored );
+}
 
 static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsyncProviderData *data )
 {
@@ -252,17 +328,53 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
             return xthreading->XAsyncSchedule( data->async, 0 );
 
         case XAsyncOp::DoWork:
+            resolve_token( (TokenAndSignatureContext *)data->context );
+            /* Sized for the wide form, which is the larger of the two shapes. */
             xthreading->XAsyncComplete( data->async, S_OK,
-                                        sizeof(XUserGetTokenAndSignatureData)
-                                        + XSTS_TOKEN_MAX + 1 + SIGNATURE_MAX + 1 );
+                                        sizeof(XUserGetTokenAndSignatureUtf16Data)
+                                        + ( XSTS_TOKEN_MAX + 1 + SIGNATURE_MAX + 1 ) * sizeof(WCHAR) );
             /* Completed here, so the framework must not complete it again. */
             return E_PENDING;
 
         case XAsyncOp::GetResult:
         {
+            auto *ctx = (TokenAndSignatureContext *)data->context;
+
+            if ( ctx && ctx->utf16 )
+            {
+                auto *wide = (XUserGetTokenAndSignatureUtf16Data *)data->buffer;
+                WCHAR *wtoken = (WCHAR *)((char *)data->buffer + sizeof(*wide));
+                char narrow[SIGNATURE_MAX];
+                WCHAR *wsignature;
+                INT count = 0;
+
+                wtoken[0] = 0;
+                if ( ctx->token )
+                {
+                    count = MultiByteToWideChar( CP_UTF8, 0, ctx->token, -1, wtoken, XSTS_TOKEN_MAX );
+                    /* The count includes the terminator, which the caller does not want. */
+                    if ( count > 0 ) count--;
+                }
+
+                wsignature = wtoken + count + 1;
+                wsignature[0] = 0;
+                narrow[0] = '\0';
+                if ( count && SUCCEEDED( sign_request( ctx->method, ctx->url, ctx->token,
+                                                       ctx->body, ctx->bodySize,
+                                                       narrow, SIGNATURE_MAX ) ) )
+                    MultiByteToWideChar( CP_UTF8, 0, narrow, -1, wsignature, SIGNATURE_MAX );
+                else if ( count )
+                    WARN( "request signature unavailable; sending the token unsigned.\n" );
+
+                wide->tokenCount = count;
+                wide->signatureCount = lstrlenW( wsignature );
+                wide->token = wtoken;
+                wide->signature = wsignature;
+                return S_OK;
+            }
+
             auto *result = (XUserGetTokenAndSignatureData *)data->buffer;
             char *token = (char *)data->buffer + sizeof(*result);
-            auto *ctx = (TokenAndSignatureContext *)data->context;
             XUserHandle user = ctx ? ctx->user : nullptr;
             HSTRING stored = nullptr;
             UINT32 length = 0;
@@ -271,18 +383,15 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
 
             token[0] = '\0';
 
-            if ( user && user->m_signature == X_USER_SIGNATURE && user->m_user &&
-                 SUCCEEDED( ctx->playfab ? user->m_user->GetPlayfabToken( &stored )
-                                         : user->m_user->GetXstsToken( &stored ) ) )
+            if ( ctx && ctx->token )
             {
-                raw = WindowsGetStringRawBuffer( stored, &length );
-                if ( raw && length )
-                    written = WideCharToMultiByte( CP_UTF8, 0, raw, length,
-                                                   token, XSTS_TOKEN_MAX, nullptr, nullptr );
-                WindowsDeleteString( stored );
+                written = (INT)strlen( ctx->token );
+                if ( written > XSTS_TOKEN_MAX ) written = XSTS_TOKEN_MAX;
+                memcpy( token, ctx->token, written );
             }
 
             token[written] = '\0';
+            (void)user; (void)stored; (void)raw; (void)length;
 
             char *signature = token + written + 1;
             signature[0] = '\0';
@@ -311,6 +420,7 @@ static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsync
                 free( ctx->method );
                 free( ctx->url );
                 free( ctx->body );
+                free( ctx->token );
             }
             delete ctx;
             break;
@@ -329,7 +439,8 @@ static char *dup_string( const char *value )
 }
 
 static HRESULT begin_token_and_signature( XUserHandle user, const char *method, const char *url,
-                                          const void *body, SIZE_T bodySize, XAsyncBlock *async )
+                                          const void *body, SIZE_T bodySize, XAsyncBlock *async,
+                                          bool utf16 = false )
 {
     IXThreadingImpl *xthreading;
     HRESULT hr;
@@ -347,6 +458,8 @@ static HRESULT begin_token_and_signature( XUserHandle user, const char *method, 
     ctx->url = dup_string( url );
     ctx->bodySize = body ? bodySize : 0;
     ctx->body = nullptr;
+    ctx->token = nullptr;
+    ctx->utf16 = utf16;
     if ( ctx->bodySize && (ctx->body = malloc( ctx->bodySize )) )
         memcpy( ctx->body, body, ctx->bodySize );
 
@@ -522,8 +635,23 @@ public:
 
     INT32 WINAPI XUserCompare( XUserHandle user1, XUserHandle user2 ) override
     {
-        FIXME( "user1 %p, user2 %p stub!\n", user1, user2 );
-        return E_NOTIMPL;
+        UINT64 xuid1, xuid2;
+
+        TRACE( "user1 %p, user2 %p.\n", user1, user2 );
+
+        /* This is an ordering, not an HRESULT. Callers read zero as "the same user",
+         * so returning a failure code here means no two handles ever match and a
+         * caller looking for one spins forever. */
+        if ( user1 == user2 ) return 0;
+
+        xuid1 = ( user1 && user1->m_signature == X_USER_SIGNATURE && user1->m_user )
+                ? user1->m_user->GetXuid() : 0;
+        xuid2 = ( user2 && user2->m_signature == X_USER_SIGNATURE && user2->m_user )
+                ? user2->m_user->GetXuid() : 0;
+
+        if ( xuid1 < xuid2 ) return -1;
+        if ( xuid1 > xuid2 ) return 1;
+        return 0;
     }
 
     HRESULT WINAPI XUserGetMaxUsers( UINT32 *maxUsers ) override
@@ -593,8 +721,16 @@ public:
 
     HRESULT WINAPI XUserFindUserById( UINT64 userId, XUserHandle *handle ) override
     {
-        FIXME( "userId %llu, handle %p stub!\n", userId, handle );
-        return E_NOTIMPL;
+        TRACE( "userId %llu, handle %p.\n", userId, handle );
+
+        if ( !handle ) return E_POINTER;
+        /* One user is signed in, so the only id that can resolve is theirs. */
+        if ( !g_current_user || !g_current_user->m_user ||
+             g_current_user->m_user->GetXuid() != userId )
+            return E_GAMEUSER_NO_DEFAULT_USER;
+
+        *handle = g_current_user;
+        return S_OK;
     }
 
     HRESULT STDMETHODCALLTYPE XUserGetGamertag( XUserHandle user, XUserGamertagComponent gamertagComponent,
@@ -781,20 +917,32 @@ public:
         if ( method )
             WideCharToMultiByte( CP_UTF8, 0, method, -1, methodA, sizeof(methodA), nullptr, nullptr );
 
-        return begin_token_and_signature( user, methodA, urlA, bodyBuffer, bodySize, async );
+        return begin_token_and_signature( user, methodA, urlA, bodyBuffer, bodySize, async, true );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureUtf16ResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override
     {
-        FIXME( "async %p, bufferSize %p stub!\n", async, bufferSize );
-        if ( bufferSize ) *bufferSize = 0;
-        return E_NOTIMPL;
+        TRACE( "async %p, bufferSize %p.\n", async, bufferSize );
+        return token_and_signature_result_size( async, bufferSize );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureUtf16Result( XAsyncBlock *async, SIZE_T bufferSize, void *buffer, XUserGetTokenAndSignatureUtf16Data **ptrToBuffer, SIZE_T *bufferUsed ) override
     {
-        FIXME( "async %p, bufferSize %Iu, buffer %p, ptrToBuffer %p, bufferUsed %p stub!\n", async, bufferSize, buffer, ptrToBuffer, bufferUsed );
-        return E_NOTIMPL;
+        IXThreadingImpl *xthreading;
+        HRESULT hr;
+
+        TRACE( "async %p, bufferSize %Iu, buffer %p, ptrToBuffer %p, bufferUsed %p.\n",
+               async, bufferSize, buffer, ptrToBuffer, bufferUsed );
+
+        if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+            return hr;
+
+        hr = xthreading->XAsyncGetResult( async, (void *)token_and_signature_provider,
+                                          bufferSize, buffer, bufferUsed );
+        if ( SUCCEEDED( hr ) && ptrToBuffer )
+            *ptrToBuffer = (XUserGetTokenAndSignatureUtf16Data *)buffer;
+
+        return hr;
     }
 
     HRESULT WINAPI XUserResolveIssueWithUiAsync( XUserHandle user, const char *url, XAsyncBlock *async ) override
@@ -956,3 +1104,115 @@ public:
 static XUserImpl g_x_user;
 
 IXUserImpl *x_user = static_cast<IXUserImpl*>(&g_x_user);
+
+/* Titles that start on a "press to begin" screen use this to work out which user a
+ * given input device belongs to. xodus signs in exactly one user, so every device
+ * maps to that one. */
+class XUserDeviceImpl :
+    public IXUserDeviceImpl2
+{
+public:
+    HRESULT WINAPI QueryInterface( REFIID iid, void **out ) override
+    {
+        TRACE( "iface %p, iid %s, out %p.\n", this, debugstr_guid( &iid ), out );
+
+        if (!out) return E_POINTER;
+        *out = nullptr;
+
+        if ( iid == __uuidof( IUnknown ) ||
+             iid == __uuidof( IXUserDeviceImpl ) ||
+             iid == __uuidof( IXUserDeviceImpl2 ) )
+        {
+            AddRef();
+            *out = static_cast<IXUserDeviceImpl2 *>(this);
+            return S_OK;
+        }
+
+        FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( &iid ) );
+        return E_NOINTERFACE;
+    }
+
+    ULONG WINAPI AddRef() noexcept override { return static_cast<ULONG>(++ref); }
+    ULONG WINAPI Release() noexcept override { return static_cast<ULONG>(--ref); }
+
+    HRESULT WINAPI XUserFindForDevice( const APP_LOCAL_DEVICE_ID *deviceId, XUserHandle *handle ) override
+    {
+        TRACE( "deviceId %p, handle %p.\n", deviceId, handle );
+
+        if ( !handle ) return E_POINTER;
+        if ( !g_current_user ) return E_GAMEUSER_NO_DEFAULT_USER;
+
+        *handle = g_current_user;
+        return S_OK;
+    }
+
+    HRESULT WINAPI XUserRegisterForDeviceAssociationChanged( XTaskQueueHandle queue, void *context,
+                                                             XUserDeviceAssociationChangedCallback *callback,
+                                                             XTaskQueueRegistrationToken *token ) override
+    {
+        FIXME( "queue %p, context %p, callback %p semi-stub: the association never changes.\n",
+               queue, context, callback );
+
+        /* The caller unregisters with this later, so it has to be written even though
+         * no change will ever be reported. */
+        if ( token ) token->token = ++m_nextToken;
+        return S_OK;
+    }
+
+    BOOLEAN WINAPI XUserUnregisterForDeviceAssociationChanged( XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        TRACE( "token %llu, wait %d.\n", (UINT64)token.token, wait );
+        return TRUE;
+    }
+
+    HRESULT WINAPI XUserGetDefaultAudioEndpointUtf16( XUserLocalId user, XUserDefaultAudioEndpointKind kind,
+                                                      SIZE_T count, WCHAR *endpointId, SIZE_T *used ) override
+    {
+        FIXME( "user %llu, kind %d, count %Iu stub!\n", (UINT64)user.value, (int)kind, count );
+        return E_NOTIMPL;
+    }
+
+    HRESULT WINAPI XUserRegisterForDefaultAudioEndpointUtf16Changed( XTaskQueueHandle queue, void *context,
+                                                                     XUserDefaultAudioEndpointUtf16ChangedCallback *callback,
+                                                                     XTaskQueueRegistrationToken *token ) override
+    {
+        FIXME( "queue %p, context %p, callback %p semi-stub: the endpoint never changes.\n",
+               queue, context, callback );
+        if ( token ) token->token = ++m_nextToken;
+        return S_OK;
+    }
+
+    BOOLEAN WINAPI XUserUnregisterForDefaultAudioEndpointUtf16Changed( XTaskQueueRegistrationToken token, BOOLEAN wait ) override
+    {
+        TRACE( "token %llu, wait %d.\n", (UINT64)token.token, wait );
+        return TRUE;
+    }
+
+    HRESULT WINAPI XUserFindControllerForUserWithUiAsync( XUserHandle user, XAsyncBlock *async ) override
+    {
+        FIXME( "user %p, async %p semi-stub: answering with the device the title already has.\n",
+               user, async );
+        return XAsyncRun( async, controller_work );
+    }
+
+    HRESULT WINAPI XUserFindControllerForUserWithUiResult( XAsyncBlock *async, APP_LOCAL_DEVICE_ID *deviceId ) override
+    {
+        TRACE( "async %p, deviceId %p.\n", async, deviceId );
+
+        if ( !deviceId ) return E_POINTER;
+        /* A zeroed id means "whichever device the title is already reading", which is
+         * the only answer that fits a single-user desktop. */
+        memset( deviceId, 0, sizeof(*deviceId) );
+        return S_OK;
+    }
+
+private:
+    static HRESULT __stdcall controller_work( XAsyncBlock * ) { return S_OK; }
+
+    std::atomic_long ref{ 1 };
+    std::atomic<UINT64> m_nextToken{ 0 };
+};
+
+static XUserDeviceImpl g_x_user_device;
+
+IXUserDeviceImpl2 *x_user_device = static_cast<IXUserDeviceImpl2 *>(&g_x_user_device);

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -20,11 +20,147 @@
  */
 
 #include "../../private.h"
+#include "User/UserImpl.h"
 
 #include <cstring>
 #include <atomic>
+#include <new>
 
 WINE_DEFAULT_DEBUG_CHANNEL(gdkc);
+
+static HRESULT __stdcall not_implemented_async_work( XAsyncBlock * )
+{
+    return E_NOTIMPL;
+}
+
+/* No XSTS token or request signature is available yet - the xodus IPC protocol only
+ * carries MSA tokens. Hand back an empty but well-formed result so callers get a
+ * definite answer instead of a failure they turn into an exception. */
+/* An XSTS header is a few kilobytes of base64. */
+#define XSTS_TOKEN_MAX 8192
+
+/* Which service the caller is authenticating to decides which stored token fits;
+ * both travel to GetResult as the provider context. */
+struct TokenAndSignatureContext
+{
+    XUserHandle user;
+    bool playfab;
+};
+
+static HRESULT __stdcall token_and_signature_provider( XAsyncOp op, const XAsyncProviderData *data )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    switch (op)
+    {
+        case XAsyncOp::Begin:
+            return xthreading->XAsyncSchedule( data->async, 0 );
+
+        case XAsyncOp::DoWork:
+            xthreading->XAsyncComplete( data->async, S_OK,
+                                        sizeof(XUserGetTokenAndSignatureData)
+                                        + XSTS_TOKEN_MAX + 1 );
+            /* Completed here, so the framework must not complete it again. */
+            return E_PENDING;
+
+        case XAsyncOp::GetResult:
+        {
+            auto *result = (XUserGetTokenAndSignatureData *)data->buffer;
+            char *token = (char *)data->buffer + sizeof(*result);
+            auto *ctx = (TokenAndSignatureContext *)data->context;
+            XUserHandle user = ctx ? ctx->user : nullptr;
+            HSTRING stored = nullptr;
+            UINT32 length = 0;
+            LPCWSTR raw;
+            INT written = 0;
+
+            token[0] = '\0';
+
+            if ( user && user->m_signature == X_USER_SIGNATURE && user->m_user &&
+                 SUCCEEDED( ctx->playfab ? user->m_user->GetPlayfabToken( &stored )
+                                         : user->m_user->GetXstsToken( &stored ) ) )
+            {
+                raw = WindowsGetStringRawBuffer( stored, &length );
+                if ( raw && length )
+                    written = WideCharToMultiByte( CP_UTF8, 0, raw, length,
+                                                   token, XSTS_TOKEN_MAX, nullptr, nullptr );
+                WindowsDeleteString( stored );
+            }
+
+            token[written] = '\0';
+
+            /* No request signature: Xbox signs requests with the device key, which
+             * xodus does not hold. The token alone is what most services check. */
+            result->tokenSize = written;
+            result->signatureSize = 0;
+            result->token = token;
+            result->signature = token + written;
+            return S_OK;
+        }
+
+        case XAsyncOp::Cleanup:
+            delete (TokenAndSignatureContext *)data->context;
+            break;
+
+        default:
+            break;
+    }
+
+    return S_OK;
+}
+
+static HRESULT begin_token_and_signature( XUserHandle user, const char *url, XAsyncBlock *async )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    auto *ctx = new (std::nothrow) TokenAndSignatureContext;
+    if ( !ctx ) return E_OUTOFMEMORY;
+
+    ctx->user = user;
+    ctx->playfab = url && strstr( url, "playfab" ) != nullptr;
+
+    hr = xthreading->XAsyncBegin( async, ctx, (void *)token_and_signature_provider,
+                                  "XUserGetTokenAndSignature", token_and_signature_provider );
+    if ( FAILED( hr ) ) delete ctx;
+
+    return hr;
+}
+
+static HRESULT token_and_signature_result( XAsyncBlock *async, SIZE_T bufferSize, void *buffer,
+                                           XUserGetTokenAndSignatureData **ptrToBuffer, SIZE_T *bufferUsed )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    hr = xthreading->XAsyncGetResult( async, (void *)token_and_signature_provider,
+                                      bufferSize, buffer, bufferUsed );
+    if ( SUCCEEDED( hr ) && ptrToBuffer )
+        *ptrToBuffer = (XUserGetTokenAndSignatureData *)buffer;
+
+    return hr;
+}
+
+static HRESULT token_and_signature_result_size( XAsyncBlock *async, SIZE_T *bufferSize )
+{
+    IXThreadingImpl *xthreading;
+    HRESULT hr;
+
+    if ( FAILED( hr = QueryApiImpl( &CLSID_XThreadingImpl, IID_IXThreadingImpl, (void **)&xthreading ) ) )
+        return hr;
+
+    return xthreading->XAsyncGetResultSize( async, bufferSize );
+}
 
 class XUserImpl : 
     public IXUserImpl6
@@ -128,8 +264,22 @@ public:
 
     HRESULT WINAPI XUserDuplicateHandle( XUserHandle handle, XUserHandle *duplicatedHandle ) override
     {
-        FIXME( "handle %p, duplicatedHandle %p stub!\n", handle, duplicatedHandle );
-        return E_NOTIMPL;
+        TRACE( "handle %p, duplicatedHandle %p.\n", handle, duplicatedHandle );
+
+        if ( !duplicatedHandle ) return E_POINTER;
+        if ( !handle || handle->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* The duplicate has to survive XUserCloseHandle on either copy, so it gets
+         * its own struct and a reference on the shared user object. */
+        XUser *copy = new (std::nothrow) XUser;
+        if ( !copy ) return E_OUTOFMEMORY;
+
+        copy->m_signature = X_USER_SIGNATURE;
+        copy->m_user = handle->m_user;
+        if ( copy->m_user ) copy->m_user->AddRef();
+
+        *duplicatedHandle = copy;
+        return S_OK;
     }
 
     void WINAPI XUserCloseHandle( XUserHandle user ) override
@@ -152,20 +302,27 @@ public:
 
     HRESULT WINAPI XUserAddAsync( XUserAddOptions options, XAsyncBlock *async ) override
     {
-        FIXME( "options %d, async %p stub!\n", (int)options, async );
-        return E_NOTIMPL;
+        TRACE( "options %d, async %p.\n", (int)options, async );
+        return ::XUserAddAsync( options, async );
     }
 
     HRESULT WINAPI XUserAddResult( XAsyncBlock *async, XUserHandle *newUser ) override
     {
-        FIXME( "async %p, newUser %p stub!\n", async, newUser );
-        return E_NOTIMPL;
+        TRACE( "async %p, newUser %p.\n", async, newUser );
+        return ::XUserAddResult( async, newUser );
     }
 
     HRESULT WINAPI XUserGetLocalId( XUserHandle user, XUserLocalId *userLocalId ) override
     {
-        FIXME( "user %p, userLocalId %p stub!\n", user, userLocalId );
-        return E_NOTIMPL;
+        TRACE( "user %p, userLocalId %p.\n", user, userLocalId );
+
+        if ( !userLocalId ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* Keyed on the shared user object, not the handle: XUserDuplicateHandle hands
+         * out a second handle for the same user, and both must report one id. */
+        userLocalId->value = (UINT64)(ULONG_PTR)user->m_user;
+        return S_OK;
     }
 
     HRESULT WINAPI XUserFindUserByLocalId( XUserLocalId userLocalId, XUserHandle *handle ) override
@@ -176,8 +333,20 @@ public:
 
     HRESULT WINAPI XUserGetId( XUserHandle user, UINT64 *userId ) override
     {
-        FIXME( "user %p, userId %p stub!\n", user, userId );
-        return E_NOTIMPL;
+        TRACE( "user %p, userId %p.\n", user, userId );
+
+        if ( !userId ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE || !user->m_user )
+            return E_GAMERUNTIME_INVALID_HANDLE;
+
+        *userId = user->m_user->GetXuid();
+        if ( !*userId )
+        {
+            WARN( "no XUID for user %p; the XSTS exchange did not complete.\n", user );
+            return E_GAMEUSER_NO_AUTH_USER;
+        }
+
+        return S_OK;
     }
 
     HRESULT WINAPI XUserFindUserById( UINT64 userId, XUserHandle *handle ) override
@@ -188,14 +357,25 @@ public:
 
     HRESULT WINAPI XUserGetIsGuest( XUserHandle user, BOOLEAN *isGuest ) override
     {
-        FIXME( "user %p, isGuest %p stub!\n", user, isGuest );
-        return E_NOTIMPL;
+        TRACE( "user %p, isGuest %p.\n", user, isGuest );
+
+        if ( !isGuest ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* xodus signs in the account that owns the tokens, never a guest. */
+        *isGuest = FALSE;
+        return S_OK;
     }
 
     HRESULT WINAPI XUserGetState( XUserHandle user, XUserState *state ) override
     {
-        FIXME( "user %p, state %p stub!\n", user, state );
-        return E_NOTIMPL;
+        TRACE( "user %p, state %p.\n", user, state );
+
+        if ( !state ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        *state = XUserState::SignedIn;
+        return S_OK;
     }
 
     HRESULT WINAPI __PADDING__() override
@@ -206,19 +386,29 @@ public:
 
     HRESULT WINAPI XUserGetGamerPictureAsync( XUserHandle user, XUserGamerPictureSize pictureSize, XAsyncBlock *async ) override
     {
-        FIXME( "user %p, pictureSize %d, async %p stub!\n", user, (int)pictureSize, async );
-        return E_NOTIMPL;
+        FIXME( "user %p, pictureSize %d semi-stub: no gamer picture.\n", user, (int)pictureSize );
+
+        /* Callers wait on the block, so the failure has to be delivered through the
+         * async completion rather than returned synchronously. */
+        return XAsyncRun( async, not_implemented_async_work );
     }
 
     HRESULT WINAPI XUserGetGamerPictureResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override
     {
-        FIXME( "async %p, bufferSize %p stub!\n", async, bufferSize );
+        TRACE( "async %p, bufferSize %p: no picture.\n", async, bufferSize );
+
+        /* The size has to be written even when reporting failure - callers size an
+         * allocation from it and would otherwise use whatever was on the stack. */
+        if ( !bufferSize ) return E_POINTER;
+        *bufferSize = 0;
         return E_NOTIMPL;
     }
 
     HRESULT WINAPI XUserGetGamerPictureResult( XAsyncBlock *async, SIZE_T bufferSize, void *buffer, SIZE_T *bufferUsed ) override
     {
-        FIXME( "async %p, bufferSize %Iu, buffer %p, bufferUsed %p stub!\n", async, bufferSize, buffer, bufferUsed );
+        TRACE( "async %p, bufferSize %Iu, buffer %p, bufferUsed %p: no picture.\n", async, bufferSize, buffer, bufferUsed );
+
+        if ( bufferUsed ) *bufferUsed = 0;
         return E_NOTIMPL;
     }
 
@@ -230,8 +420,16 @@ public:
 
     HRESULT WINAPI XUserCheckPrivilege( XUserHandle user, XUserPrivilegeOptions options, XUserPrivilege privilege, BOOLEAN *hasPrivilege, XUserPrivilegeDenyReason *reason ) override
     {
-        FIXME( "user %p, options %d, privilege %d, hasPrivilege %p, reason %p stub!\n", user, (int)options, (int)privilege, hasPrivilege, reason );
-        return E_NOTIMPL;
+        FIXME( "user %p, options %d, privilege %d semi-stub: granting.\n", user, (int)options, (int)privilege );
+
+        if ( !hasPrivilege ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* Privileges are not queried from Xbox Live yet; grant them so the caller
+         * gets a definite answer instead of an uninitialized one. */
+        *hasPrivilege = TRUE;
+        if ( reason ) *reason = XUserPrivilegeDenyReason::None;
+        return S_OK;
     }
 
     HRESULT WINAPI XUserResolvePrivilegeWithUiAsync( XUserHandle user, XUserPrivilegeOptions options, XUserPrivilege privilege, XAsyncBlock *async ) override
@@ -249,30 +447,41 @@ public:
     HRESULT WINAPI XUserGetTokenAndSignatureAsync( XUserHandle user, XUserGetTokenAndSignatureOptions options, const char *method, const char *url, SIZE_T headerCount, const XUserGetTokenAndSignatureHttpHeader *headers, SIZE_T bodySize, const void *bodyBuffer, XAsyncBlock *async ) override
     {
         FIXME( "user %p, options %d, method %s, url %s, headerCount %Iu, headers %p, bodySize %Iu, bodyBuffer %p, async %p stub!\n", user, (int)options, debugstr_a( method ), debugstr_a( url ), headerCount, headers, bodySize, bodyBuffer, async );
-        return E_NOTIMPL;
+        /* The caller waits on the block; a synchronous failure leaves it pending
+         * and the request is torn down half-initialized. */
+        return begin_token_and_signature( user, url, async );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override
     {
-        FIXME( "async %p, bufferSize %p stub!\n", async, bufferSize );
-        return E_NOTIMPL;
+        TRACE( "async %p, bufferSize %p.\n", async, bufferSize );
+        return token_and_signature_result_size( async, bufferSize );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureResult( XAsyncBlock *async, SIZE_T bufferSize, void *buffer, XUserGetTokenAndSignatureData **ptrToBuffer, SIZE_T *bufferUsed ) override
     {
-        FIXME( "async %p, bufferSize %Iu, buffer %p, ptrToBuffer %p, bufferUsed %p stub!\n", async, bufferSize, buffer, ptrToBuffer, bufferUsed );
-        return E_NOTIMPL;
+        TRACE( "async %p, bufferSize %Iu, buffer %p, ptrToBuffer %p, bufferUsed %p.\n", async, bufferSize, buffer, ptrToBuffer, bufferUsed );
+        return token_and_signature_result( async, bufferSize, buffer, ptrToBuffer, bufferUsed );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureUtf16Async( XUserHandle user, XUserGetTokenAndSignatureOptions options, const WCHAR *method, const WCHAR *url, SIZE_T headerCount, const XUserGetTokenAndSignatureUtf16HttpHeader *headers, SIZE_T bodySize, const void *bodyBuffer, XAsyncBlock *async ) override
     {
-        FIXME( "user %p, options %d, method %s, url %s, headerCount %Iu, headers %p, bodySize %Iu, bodyBuffer %p, async %p stub!\n", user, (int)options, debugstr_w( method ), debugstr_w( url ), headerCount, headers, bodySize, bodyBuffer, async );
-        return E_NOTIMPL;
+        CHAR urlA[512];
+
+        TRACE( "user %p, options %d, method %s, url %s.\n",
+               user, (int)options, debugstr_w( method ), debugstr_w( url ) );
+
+        urlA[0] = '\0';
+        if ( url )
+            WideCharToMultiByte( CP_UTF8, 0, url, -1, urlA, sizeof(urlA), nullptr, nullptr );
+
+        return begin_token_and_signature( user, urlA, async );
     }
 
     HRESULT WINAPI XUserGetTokenAndSignatureUtf16ResultSize( XAsyncBlock *async, SIZE_T *bufferSize ) override
     {
         FIXME( "async %p, bufferSize %p stub!\n", async, bufferSize );
+        if ( bufferSize ) *bufferSize = 0;
         return E_NOTIMPL;
     }
 
@@ -308,14 +517,19 @@ public:
 
     HRESULT WINAPI XUserRegisterForChangeEvent( XTaskQueueHandle queue, void *context, XUserChangeEventCallback *callback, XTaskQueueRegistrationToken *token ) override
     {
-        FIXME( "queue %p, context %p, callback %p, token %p stub!\n", queue, context, callback, token );
-        return E_NOTIMPL;
+        FIXME( "queue %p, context %p, callback %p semi-stub: no change events are raised.\n", queue, context, callback );
+
+        /* The single xodus user never signs out mid-session, so nothing will fire.
+         * The caller still keeps the token and unregisters with it later, so it has
+         * to be a real value rather than left uninitialized. */
+        if ( token ) token->token = ++m_NextChangeEventToken;
+        return S_OK;
     }
 
     BOOLEAN WINAPI XUserUnregisterForChangeEvent( XTaskQueueRegistrationToken token, BOOLEAN wait ) override
     {
-        FIXME( "token %p, wait %d stub!\n", &token, wait );
-        return FALSE;
+        TRACE( "token %llu, wait %d.\n", (UINT64)token.token, wait );
+        return TRUE;
     }
 
     HRESULT WINAPI XUserGetSignOutDeferral( XUserSignOutDeferralHandle *deferral ) override
@@ -345,7 +559,9 @@ public:
     HRESULT WINAPI XUserGetMsaTokenSilentlyAsync( XUserHandle user, XUserGetMsaTokenSilentlyOptions options, const char *scope, XAsyncBlock *async ) override
     {
         FIXME( "user %p, options %u, scope %s, async %p stub!\n", user, (int)options, debugstr_a( scope ), async );
-        return E_NOTIMPL;
+        /* The caller waits on the block; a synchronous failure leaves it pending
+         * and the request is torn down half-initialized. */
+        return XAsyncRun( async, not_implemented_async_work );
     }
 
     HRESULT WINAPI XUserGetMsaTokenSilentlyResult( XAsyncBlock *async, SIZE_T resultTokenSize, char *resultToken, SIZE_T *resultTokenUsed ) override
@@ -357,6 +573,7 @@ public:
     HRESULT WINAPI XUserGetMsaTokenSilentlyResultSize( XAsyncBlock *async, SIZE_T *tokenSize ) override
     {
         FIXME( "async %p, tokenSize %p stub!\n", async, tokenSize );
+        if ( tokenSize ) *tokenSize = 0;
         return E_NOTIMPL;
     }
 
@@ -409,6 +626,7 @@ public:
     }
 
     std::atomic_long ref{ 1 };
+    std::atomic<UINT64> m_NextChangeEventToken{ 0 };
 };
 
 static XUserImpl g_x_user;

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <new>
 #include <mutex>
+#include <vector>
 
 #include <bcrypt.h>
 #include <wincrypt.h>
@@ -165,6 +166,61 @@ static HRESULT sign_request( const char *method, const char *url, const char *au
 
     BCryptCloseAlgorithmProvider( sha, 0 );
     return hr;
+}
+
+/* Titles subscribe to user change events and only refresh their account UI when one
+ * arrives. Nothing here ever signs out, but a subscriber that registers after the user
+ * is already present would otherwise never hear about it and would keep showing the
+ * signed-out state, so registration replays SignedInAgain for the current user. */
+struct ChangeEventRegistration
+{
+    UINT64 token;
+    XTaskQueueHandle queue;
+    void *context;
+    XUserChangeEventCallback *callback;
+};
+
+static std::mutex g_change_events_lock;
+static std::vector<ChangeEventRegistration> g_change_events;
+static XUserHandle g_current_user = nullptr;
+
+struct ChangeEventDispatch
+{
+    void *context;
+    XUserChangeEventCallback *callback;
+    XUserLocalId localId;
+    XUserChangeEvent event;
+};
+
+static void __stdcall change_event_thunk( void *context, BOOLEAN canceled )
+{
+    auto *dispatch = (ChangeEventDispatch *)context;
+
+    if ( !canceled && dispatch->callback )
+        dispatch->callback( dispatch->context, dispatch->localId, dispatch->event );
+
+    delete dispatch;
+}
+
+static void raise_change_event( const ChangeEventRegistration &reg, XUserHandle user,
+                                XUserChangeEvent event )
+{
+    if ( !reg.callback || !user || !user->m_user ) return;
+
+    auto *dispatch = new (std::nothrow) ChangeEventDispatch;
+    if ( !dispatch ) return;
+
+    dispatch->context = reg.context;
+    dispatch->callback = reg.callback;
+    dispatch->localId.value = (UINT64)(ULONG_PTR)user->m_user;
+    dispatch->event = event;
+
+    if ( FAILED( XTaskQueueSubmitCallback( reg.queue, XTaskQueuePort::Completion,
+                                           dispatch, change_event_thunk ) ) )
+    {
+        WARN( "could not queue a user change event; delivering it inline.\n" );
+        change_event_thunk( dispatch, FALSE );
+    }
 }
 
 /* Which service the caller is authenticating to decides which stored token fits;
@@ -483,7 +539,16 @@ public:
     HRESULT WINAPI XUserAddResult( XAsyncBlock *async, XUserHandle *newUser ) override
     {
         TRACE( "async %p, newUser %p.\n", async, newUser );
-        return ::XUserAddResult( async, newUser );
+
+        HRESULT hr = ::XUserAddResult( async, newUser );
+        if ( SUCCEEDED( hr ) && newUser && *newUser && (*newUser)->m_signature == X_USER_SIGNATURE )
+        {
+            std::lock_guard<std::mutex> lock( g_change_events_lock );
+            g_current_user = *newUser;
+            for ( const auto &reg : g_change_events )
+                raise_change_event( reg, g_current_user, XUserChangeEvent::SignedInAgain );
+        }
+        return hr;
     }
 
     HRESULT WINAPI XUserGetLocalId( XUserHandle user, XUserLocalId *userLocalId ) override
@@ -636,8 +701,18 @@ public:
 
     HRESULT WINAPI XUserGetAgeGroup( XUserHandle user, XUserAgeGroup *ageGroup ) override
     {
-        FIXME( "user %p, ageGroup %p stub!\n", user, ageGroup );
-        return E_NOTIMPL;
+        TRACE( "user %p, ageGroup %p.\n", user, ageGroup );
+
+        if ( !ageGroup ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE ) return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* xodus does not carry the account's age group, and titles gate features on
+         * it - Minecraft treats an account whose age group it cannot determine as
+         * unusable and keeps offering the sign-in prompt. Reporting an adult account
+         * applies no restrictions, which matches how the signed-in account is used
+         * here; a real answer would need the profile service. */
+        *ageGroup = XUserAgeGroup::Adult;
+        return S_OK;
     }
 
     HRESULT WINAPI XUserCheckPrivilege( XUserHandle user, XUserPrivilegeOptions options, XUserPrivilege privilege, BOOLEAN *hasPrivilege, XUserPrivilegeDenyReason *reason ) override
@@ -745,19 +820,37 @@ public:
 
     HRESULT WINAPI XUserRegisterForChangeEvent( XTaskQueueHandle queue, void *context, XUserChangeEventCallback *callback, XTaskQueueRegistrationToken *token ) override
     {
-        FIXME( "queue %p, context %p, callback %p semi-stub: no change events are raised.\n", queue, context, callback );
+        TRACE( "queue %p, context %p, callback %p.\n", queue, context, callback );
 
-        /* The single xodus user never signs out mid-session, so nothing will fire.
-         * The caller still keeps the token and unregisters with it later, so it has
-         * to be a real value rather than left uninitialized. */
-        if ( token ) token->token = ++m_NextChangeEventToken;
+        if ( !callback ) return E_INVALIDARG;
+
+        ChangeEventRegistration reg{ ++m_NextChangeEventToken, queue, context, callback };
+        if ( token ) token->token = reg.token;
+
+        std::lock_guard<std::mutex> lock( g_change_events_lock );
+        g_change_events.push_back( reg );
+
+        /* Subscribers that arrive after sign-in still need to be told there is a user. */
+        if ( g_current_user )
+            raise_change_event( reg, g_current_user, XUserChangeEvent::SignedInAgain );
+
         return S_OK;
     }
 
     BOOLEAN WINAPI XUserUnregisterForChangeEvent( XTaskQueueRegistrationToken token, BOOLEAN wait ) override
     {
         TRACE( "token %llu, wait %d.\n", (UINT64)token.token, wait );
-        return TRUE;
+
+        std::lock_guard<std::mutex> lock( g_change_events_lock );
+        for ( auto it = g_change_events.begin(); it != g_change_events.end(); ++it )
+        {
+            if ( it->token == token.token )
+            {
+                g_change_events.erase( it );
+                return TRUE;
+            }
+        }
+        return FALSE;
     }
 
     HRESULT WINAPI XUserGetSignOutDeferral( XUserSignOutDeferralHandle *deferral ) override

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -196,6 +196,9 @@ static void __stdcall change_event_thunk( void *context, BOOLEAN canceled )
 {
     auto *dispatch = (ChangeEventDispatch *)context;
 
+    TRACE( "delivering change event %d for user %#llx, canceled %d.\n",
+           (int)dispatch->event, (unsigned long long)dispatch->localId.value, canceled );
+
     if ( !canceled && dispatch->callback )
         dispatch->callback( dispatch->context, dispatch->localId, dispatch->event );
 

--- a/dlls/xgameruntime/GDKComponent/System/XUser.cpp
+++ b/dlls/xgameruntime/GDKComponent/System/XUser.cpp
@@ -38,6 +38,8 @@ static HRESULT __stdcall not_implemented_async_work( XAsyncBlock * )
  * definite answer instead of a failure they turn into an exception. */
 /* An XSTS header is a few kilobytes of base64. */
 #define XSTS_TOKEN_MAX 8192
+/* XUserGamertagComponentUniqueModernMaxBytes, the largest of the four components. */
+#define XUSER_GAMERTAG_MAX 64
 
 /* Which service the caller is authenticating to decides which stored token fits;
  * both travel to GetResult as the provider context. */
@@ -162,8 +164,9 @@ static HRESULT token_and_signature_result_size( XAsyncBlock *async, SIZE_T *buff
     return xthreading->XAsyncGetResultSize( async, bufferSize );
 }
 
-class XUserImpl : 
-    public IXUserImpl6
+class XUserImpl :
+    public IXUserImpl6,
+    public IXUserGamertagImpl
 {
 public:
     HRESULT WINAPI QueryInterface( REFIID iid, void **out )
@@ -230,6 +233,15 @@ public:
         {
             AddRef();
             *out = static_cast<IXUserImpl6 *>(this);
+            return S_OK;
+        }
+
+        /* Titles ask for this separately from the main interface; without it they
+         * have no way to read the gamertag and fall back to a placeholder name. */
+        if ( iid == __uuidof( IXUserGamertagImpl ) )
+        {
+            AddRef();
+            *out = static_cast<IXUserGamertagImpl *>(this);
             return S_OK;
         }
 
@@ -353,6 +365,54 @@ public:
     {
         FIXME( "userId %llu, handle %p stub!\n", userId, handle );
         return E_NOTIMPL;
+    }
+
+    HRESULT STDMETHODCALLTYPE XUserGetGamertag( XUserHandle user, XUserGamertagComponent gamertagComponent,
+                                                SIZE_T gamertagSize, char *gamertag, SIZE_T *gamertagUsed ) override
+    {
+        char utf8[XUSER_GAMERTAG_MAX];
+        HSTRING stored = nullptr;
+        UINT32 length = 0;
+        LPCWSTR raw;
+        INT written = 0;
+
+        TRACE( "user %p, component %d, gamertagSize %Iu, gamertag %p, gamertagUsed %p.\n",
+               user, (int)gamertagComponent, gamertagSize, gamertag, gamertagUsed );
+
+        if ( !gamertag ) return E_POINTER;
+        if ( !user || user->m_signature != X_USER_SIGNATURE || !user->m_user )
+            return E_GAMERUNTIME_INVALID_HANDLE;
+
+        /* xodus reports one gamertag. The modern suffix is the part after the '#'
+         * of a unique modern gamertag, which accounts without one do not have. */
+        if ( gamertagComponent != XUserGamertagComponent::ModernSuffix &&
+             SUCCEEDED( user->m_user->GetGamertag( &stored ) ) )
+        {
+            raw = WindowsGetStringRawBuffer( stored, &length );
+            if ( raw && length )
+                written = WideCharToMultiByte( CP_UTF8, 0, raw, length,
+                                               utf8, sizeof(utf8) - 1, nullptr, nullptr );
+            WindowsDeleteString( stored );
+        }
+
+        utf8[written] = '\0';
+
+        if ( !written && gamertagComponent != XUserGamertagComponent::ModernSuffix )
+        {
+            WARN( "no gamertag for user %p; the XSTS exchange did not complete.\n", user );
+            return E_GAMEUSER_NO_AUTH_USER;
+        }
+
+        if ( gamertagSize < (SIZE_T)written + 1 )
+        {
+            if ( gamertagUsed ) *gamertagUsed = written + 1;
+            return HRESULT_FROM_WIN32( ERROR_INSUFFICIENT_BUFFER );
+        }
+
+        memcpy( gamertag, utf8, written + 1 );
+        if ( gamertagUsed ) *gamertagUsed = written + 1;
+
+        return S_OK;
     }
 
     HRESULT WINAPI XUserGetIsGuest( XUserHandle user, BOOLEAN *isGuest ) override

--- a/dlls/xgameruntime/GDKComponent/Xodus/IPCLayer.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/IPCLayer.cpp
@@ -246,8 +246,11 @@ private:
         if ( FAILED( status ) ) return status;
         if ( asyncres )
         {
+            /* STATUS_TIMEOUT is a success-class NTSTATUS, so returning it here made
+             * callers treat the timeout as a completed request and use the result
+             * that was never set. */
             WARN("Timeout while waiting for %p to respond.\n", handler);
-            return HRESULT_FROM_NT( STATUS_TIMEOUT );
+            return HRESULT_FROM_WIN32( ERROR_TIMEOUT );
         }
 
         result->vt = VT_UNKNOWN;
@@ -298,6 +301,16 @@ private:
         IXodusIPCPacket *xodusPacket = nullptr;
 
         TRACE("invoker %p, param %p, result %p\n", invoker, param, result);
+
+        /* This is a bare worker thread, so its apartment has to be initialized before
+         * any WinRT activation - otherwise RoGetActivationFactory below fails with
+         * CO_E_NOTINITIALIZED. */
+        HRESULT initHr = RoInitialize( RO_INIT_MULTITHREADED );
+        if ( FAILED( initHr ) && initHr != RPC_E_CHANGED_MODE )
+        {
+            WARN("RoInitialize failed with %#lx\n", initHr);
+            return initHr;
+        }
 
         status = WindowsCreateString( RuntimeClass_Windows_Storage_Streams_Buffer, lstrlenW( RuntimeClass_Windows_Storage_Streams_Buffer ), &bufferClass );
         if ( FAILED( status ) ) return status;

--- a/dlls/xgameruntime/GDKComponent/Xodus/Structs.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/Structs.cpp
@@ -184,6 +184,20 @@ MsaTokenResponse::MsaTokenResponse(
     WindowsDuplicateString( token, &Token );
 }
 
+MsaTokenResponse::MsaTokenResponse(
+    HSTRING token,
+    ABI::Windows::Foundation::DateTime expiry,
+    HSTRING xuid,
+    HSTRING gamertag,
+    HSTRING xstsToken )
+: Expiry(expiry)
+{
+    WindowsDuplicateString( token, &Token );
+    WindowsDuplicateString( xuid, &Xuid );
+    WindowsDuplicateString( gamertag, &Gamertag );
+    WindowsDuplicateString( xstsToken, &XstsToken );
+}
+
 HRESULT WINAPI
 MsaTokenResponse::QueryInterface( REFIID iid, void **out ) noexcept
 {
@@ -243,5 +257,29 @@ MsaTokenResponse::get_Expiry( ABI::Windows::Foundation::DateTime *out )
 {
     TRACE( "iface %p, out %p\n", this, out );
     *out = Expiry;
+    return S_OK;
+}
+
+HRESULT WINAPI
+MsaTokenResponse::get_Xuid( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( Xuid, out );
+    return S_OK;
+}
+
+HRESULT WINAPI
+MsaTokenResponse::get_Gamertag( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( Gamertag, out );
+    return S_OK;
+}
+
+HRESULT WINAPI
+MsaTokenResponse::get_XstsToken( HSTRING *out )
+{
+    TRACE( "iface %p, out %p\n", this, out );
+    WindowsDuplicateString( XstsToken, out );
     return S_OK;
 }

--- a/dlls/xgameruntime/GDKComponent/Xodus/Structs.h
+++ b/dlls/xgameruntime/GDKComponent/Xodus/Structs.h
@@ -102,6 +102,13 @@ public:
         HSTRING token,
         ABI::Windows::Foundation::DateTime expiry );
 
+    MsaTokenResponse(
+        HSTRING token,
+        ABI::Windows::Foundation::DateTime expiry,
+        HSTRING xuid,
+        HSTRING gamertag,
+        HSTRING xstsToken );
+
     MsaTokenResponse( const MsaTokenResponse& ) = delete;
     MsaTokenResponse& operator=( const MsaTokenResponse& ) = delete;
 
@@ -113,10 +120,16 @@ public:
     /* IMsaTokenResponse Methods */
     HRESULT WINAPI get_Token( HSTRING *out );
     HRESULT WINAPI get_Expiry( ABI::Windows::Foundation::DateTime *out );
+    HRESULT WINAPI get_Xuid( HSTRING *out );
+    HRESULT WINAPI get_Gamertag( HSTRING *out );
+    HRESULT WINAPI get_XstsToken( HSTRING *out );
 
 private:
     ABI::Windows::Foundation::DateTime Expiry;
     HSTRING Token;
+    HSTRING Xuid = nullptr;
+    HSTRING Gamertag = nullptr;
+    HSTRING XstsToken = nullptr;
     std::atomic_long ref{ 1 };
 };
 

--- a/dlls/xgameruntime/GDKComponent/Xodus/Unix/socket.c
+++ b/dlls/xgameruntime/GDKComponent/Xodus/Unix/socket.c
@@ -102,7 +102,8 @@
 # define HAS_IRDA
 #endif
 
-#define POLL_BUFFER_SIZE 2048
+/* Must match POLL_BUFFER_SIZE in private.h. */
+#define POLL_BUFFER_SIZE 65536
 
 WINE_DEFAULT_DEBUG_CHANNEL(xodus);
 

--- a/dlls/xgameruntime/GDKComponent/Xodus/XodusService.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/XodusService.cpp
@@ -133,12 +133,41 @@ public:
                     static_cast<PVOID>(params), MsaTokenRequestAsync, operation );
     }
 
+    HRESULT WINAPI
+    XstsTokenRequest( HSTRING clientId, HSTRING relyingParty, IAsyncOperation<IMsaTokenResponse *> **operation ) override
+    {
+        HRESULT hr;
+        HSTRING clientIdCopy;
+        HSTRING relyingPartyCopy;
+        MsaTokenRequestParams *params;
+
+        TRACE("clientId %s, relyingParty %s, operation %p.\n",
+              debugstr_hstring(clientId), debugstr_hstring(relyingParty), operation);
+
+        hr = WindowsDuplicateString( clientId, &clientIdCopy );
+        if ( FAILED( hr ) ) return hr;
+        hr = WindowsDuplicateString( relyingParty, &relyingPartyCopy );
+        if ( FAILED( hr ) )
+        {
+            WindowsDeleteString( clientIdCopy );
+            return hr;
+        }
+
+        params = new MsaTokenRequestParams( { clientIdCopy, false, false, relyingPartyCopy } );
+
+        return AsyncOperation<IMsaTokenResponse *>::Create( static_cast<IUnknown *>(this),
+                    static_cast<PVOID>(params), MsaTokenRequestAsync, operation );
+    }
+
 private:
     struct MsaTokenRequestParams
     {
         HSTRING clientId;
         boolean allowUI;
         boolean fullTrust;
+        /* Null for a plain token request; set when a specific Xbox Live relying
+         * party is wanted. */
+        HSTRING relyingParty = nullptr;
     };
 
     static HRESULT WINAPI
@@ -169,7 +198,10 @@ private:
         if ( FAILED( status ) ) goto _CLEANUP;
 
         // FIXME: Probably need to do HSTRING on xmlStr as doing manual CoTaskMemFree on xmlStr is janky.
-        status = xodus_xml_builder->BuildMsaTokenRequestXml( params->clientId, params->allowUI, params->fullTrust, &xmlStr );
+        if ( params->relyingParty )
+            status = xodus_xml_builder->BuildXstsTokenRequestXml( params->clientId, params->relyingParty, &xmlStr );
+        else
+            status = xodus_xml_builder->BuildMsaTokenRequestXml( params->clientId, params->allowUI, params->fullTrust, &xmlStr );
         if ( FAILED( status ) ) goto _CLEANUP;
 
         status = bufferFactory->Create( lstrlenA( xmlStr ) + 1, &message );
@@ -210,6 +242,12 @@ private:
 
         status = response->GetResults( &xodusPacket );
         if ( FAILED( status ) ) goto _CLEANUP;
+        if ( !xodusPacket )
+        {
+            WARN("No response packet for the MSA token request.\n");
+            status = E_FAIL;
+            goto _CLEANUP;
+        }
 
         xodusPacket->get_MessageType( &messageType );
         xodusPacket->get_Message( &message );

--- a/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
@@ -234,6 +234,10 @@ public:
 
         xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST "false" );
         xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST "false" );
+        /* This is the token titles actually authenticate with, so it needs the same
+         * binding as the main one - without it every signed request is rejected. */
+        if ( const char *proofKey = XodusProofKeyJwk() )
+            xmlNewChild( root, nullptr, BAD_CAST "ProofKey", BAD_CAST proofKey );
 
         xmlDocDumpFormatMemory( doc, &xmlBuff, &bufSize, 1 );
         xmlFreeDoc( doc );

--- a/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
@@ -37,6 +37,17 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(xodus);
 
+/* The service needs the title to ask Xbox for that title's endpoint document,
+ * which is the only place a publisher's own relying party is published. */
+static void AddTitleId( xmlNodePtr root )
+{
+    char value[16];
+
+    if ( !titleId ) return;
+    snprintf( value, sizeof(value), "%08X", titleId );
+    xmlNewChild( root, nullptr, BAD_CAST "TitleId", BAD_CAST value );
+}
+
 using namespace ABI;
 using namespace ABI::Xodus;
 using namespace ABI::Windows::Foundation;
@@ -180,6 +191,7 @@ public:
         CoTaskMemFree( clientIdStr );
         xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST (allowUI ? "true" : "false") );
         xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST (fullTrust ? "true" : "false") );
+        AddTitleId( root );
         /* Binds the issued token to our signing key, so signed requests verify. */
         if ( const char *proofKey = XodusProofKeyJwk() )
             xmlNewChild( root, nullptr, BAD_CAST "ProofKey", BAD_CAST proofKey );
@@ -234,6 +246,7 @@ public:
 
         xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST "false" );
         xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST "false" );
+        AddTitleId( root );
         /* This is the token titles actually authenticate with, so it needs the same
          * binding as the main one - without it every signed request is rejected. */
         if ( const char *proofKey = XodusProofKeyJwk() )

--- a/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
@@ -180,6 +180,9 @@ public:
         CoTaskMemFree( clientIdStr );
         xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST (allowUI ? "true" : "false") );
         xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST (fullTrust ? "true" : "false") );
+        /* Binds the issued token to our signing key, so signed requests verify. */
+        if ( const char *proofKey = XodusProofKeyJwk() )
+            xmlNewChild( root, nullptr, BAD_CAST "ProofKey", BAD_CAST proofKey );
         xmlDocDumpFormatMemory( doc, &xmlBuff, &bufSize, 1 );
         xmlFreeDoc( doc );
 

--- a/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
+++ b/dlls/xgameruntime/GDKComponent/Xodus/XodusXMLBuilder.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "../../private.h"
+
+#include <utility>
 #include "../../WineCoreUAP/Foundation/IWineAsync.hpp"
 #include "../../WineCoreUAP/Foundation/IWineVector.hpp"
 #include "Structs.h"
@@ -39,6 +41,32 @@ using namespace ABI;
 using namespace ABI::Xodus;
 using namespace ABI::Windows::Foundation;
 using namespace ABI::Windows::Foundation::Collections;
+
+/* The response carries several plain-text elements; they all convert the same way. */
+static HRESULT hstring_from_node( xmlNodePtr node, HSTRING *out )
+{
+    xmlChar *content = xmlNodeGetContent( node );
+    INT strLen;
+    LPWSTR strW;
+    HRESULT hr;
+
+    if ( !content ) return E_FAIL;
+
+    strLen = MultiByteToWideChar( CP_UTF8, 0, reinterpret_cast<LPCSTR>(content), -1, nullptr, 0 );
+    strW = (LPWSTR)CoTaskMemAlloc( strLen * sizeof(WCHAR) );
+    if ( !strW )
+    {
+        xmlFree( content );
+        return E_OUTOFMEMORY;
+    }
+
+    MultiByteToWideChar( CP_UTF8, 0, reinterpret_cast<LPCSTR>(content), -1, strW, strLen );
+    hr = WindowsCreateString( strW, strLen - 1, out );
+
+    CoTaskMemFree( strW );
+    xmlFree( content );
+    return hr;
+}
 
 class ABI::Xodus::XodusXMLBuilder :
     public IXodusXMLBuilder
@@ -138,21 +166,77 @@ public:
 
         TRACE( "clientId %s, xml_string %p.\n", debugstr_hstring(clientId), xml_string );
 
+        /* An explicit source length means the result is not NUL terminated, so leave
+         * room for the terminator libxml2 expects when reading it as a C string. */
         clientIdStrSize = WideCharToMultiByte( CP_UTF8, 0, clientIdStrW, clientIdStrLen, nullptr, 0, nullptr, nullptr );
-        clientIdStr = (LPSTR)CoTaskMemAlloc( clientIdStrSize );
+        clientIdStr = (LPSTR)CoTaskMemAlloc( clientIdStrSize + 1 );
         WideCharToMultiByte( CP_UTF8, 0, clientIdStrW, clientIdStrLen, clientIdStr, clientIdStrSize, nullptr, nullptr );
+        clientIdStr[clientIdStrSize] = '\0';
 
         root = xmlNewNode( nullptr, BAD_CAST "MsaTokenRequest" );
         xmlDocSetRootElement(doc, root);
-        xmlNewChild( root, nullptr, BAD_CAST "clientId", BAD_CAST clientIdStr );
+        /* The service deserializes these names in PascalCase. */
+        xmlNewChild( root, nullptr, BAD_CAST "ClientId", BAD_CAST clientIdStr );
         CoTaskMemFree( clientIdStr );
         xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST (allowUI ? "true" : "false") );
         xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST (fullTrust ? "true" : "false") );
         xmlDocDumpFormatMemory( doc, &xmlBuff, &bufSize, 1 );
         xmlFreeDoc( doc );
 
-        *xml_string = (LPSTR)CoTaskMemAlloc( bufSize );
-        lstrcpynA( *xml_string, reinterpret_cast<LPCSTR>(xmlBuff), bufSize );
+        /* bufSize excludes the terminator, and lstrcpynA reserves one - without the
+         * extra byte the document loses its last character. */
+        *xml_string = (LPSTR)CoTaskMemAlloc( bufSize + 1 );
+        lstrcpynA( *xml_string, reinterpret_cast<LPCSTR>(xmlBuff), bufSize + 1 );
+        xmlFree( xmlBuff );
+
+        return S_OK;
+    }
+
+    HRESULT WINAPI
+    BuildXstsTokenRequestXml( HSTRING clientId, HSTRING relyingParty, LPSTR *xml_string ) override
+    {
+        INT bufSize;
+        INT strSize;
+        LPSTR str;
+        UINT32 strLen;
+        LPCWSTR strW;
+        xmlChar *xmlBuff = nullptr;
+        xmlDocPtr doc = xmlNewDoc( BAD_CAST "1.0" );
+        xmlNodePtr root;
+
+        TRACE( "clientId %s, relyingParty %s, xml_string %p.\n",
+               debugstr_hstring( clientId ), debugstr_hstring( relyingParty ), xml_string );
+
+        root = xmlNewNode( nullptr, BAD_CAST "MsaTokenRequest" );
+        xmlDocSetRootElement( doc, root );
+
+        /* The service answers this exactly like a token request, with the Xbox
+         * identity resolved for the party we name here. */
+        for ( auto entry : { std::make_pair( "ClientId", clientId ),
+                             std::make_pair( "RelyingParty", relyingParty ) } )
+        {
+            strW = WindowsGetStringRawBuffer( entry.second, &strLen );
+            strSize = WideCharToMultiByte( CP_UTF8, 0, strW, strLen, nullptr, 0, nullptr, nullptr );
+            str = (LPSTR)CoTaskMemAlloc( strSize + 1 );
+            if ( !str )
+            {
+                xmlFreeDoc( doc );
+                return E_OUTOFMEMORY;
+            }
+            WideCharToMultiByte( CP_UTF8, 0, strW, strLen, str, strSize, nullptr, nullptr );
+            str[strSize] = '\0';
+            xmlNewChild( root, nullptr, BAD_CAST entry.first, BAD_CAST str );
+            CoTaskMemFree( str );
+        }
+
+        xmlNewChild( root, nullptr, BAD_CAST "AllowUi", BAD_CAST "false" );
+        xmlNewChild( root, nullptr, BAD_CAST "MsaFullTrust", BAD_CAST "false" );
+
+        xmlDocDumpFormatMemory( doc, &xmlBuff, &bufSize, 1 );
+        xmlFreeDoc( doc );
+
+        *xml_string = (LPSTR)CoTaskMemAlloc( bufSize + 1 );
+        lstrcpynA( *xml_string, reinterpret_cast<LPCSTR>(xmlBuff), bufSize + 1 );
         xmlFree( xmlBuff );
 
         return S_OK;
@@ -166,6 +250,9 @@ public:
         LPWSTR strW;
         HRESULT hr;
         HSTRING token = nullptr;
+        HSTRING xuid = nullptr;
+        HSTRING gamertag = nullptr;
+        HSTRING xstsToken = nullptr;
         DateTime expiry{};
         LONGLONG expiryUnix;
         xmlChar *childContent;
@@ -212,9 +299,27 @@ public:
                     expiry.UniversalTime = ((INT64)expiryUnix + SEC_TO_UNIX_EPOCH) * WINDOWS_TICK;
                     CoTaskMemFree( str );
                 }
+                else if ( curr_child->type == XML_ELEMENT_NODE &&
+                          !strcmp( reinterpret_cast<LPCSTR>(curr_child->name), "Xuid" ) )
+                {
+                    hstring_from_node( curr_child, &xuid );
+                }
+                else if ( curr_child->type == XML_ELEMENT_NODE &&
+                          !strcmp( reinterpret_cast<LPCSTR>(curr_child->name), "Gamertag" ) )
+                {
+                    hstring_from_node( curr_child, &gamertag );
+                }
+                else if ( curr_child->type == XML_ELEMENT_NODE &&
+                          !strcmp( reinterpret_cast<LPCSTR>(curr_child->name), "XstsToken" ) )
+                {
+                    hstring_from_node( curr_child, &xstsToken );
+                }
             }
 
-        *response = new MsaTokenResponse( token, expiry );
+        *response = new MsaTokenResponse( token, expiry, xuid, gamertag, xstsToken );
+        WindowsDeleteString( xuid );
+        WindowsDeleteString( gamertag );
+        WindowsDeleteString( xstsToken );
         xmlFreeDoc( doc );
         return S_OK;
     }

--- a/dlls/xgameruntime/Makefile.in
+++ b/dlls/xgameruntime/Makefile.in
@@ -24,6 +24,7 @@ SOURCES = \
 	GDKComponent/System/XSystemAnalytics.cpp \
 	GDKComponent/System/XNetworking.cpp \
 	GDKComponent/System/XUser.cpp \
+	GDKComponent/System/XStore.cpp \
 	\
 	GDKComponent/Xodus/Structs.cpp \
 	GDKComponent/Xodus/IPCLayer.cpp \

--- a/dlls/xgameruntime/Makefile.in
+++ b/dlls/xgameruntime/Makefile.in
@@ -1,4 +1,4 @@
-IMPORTS   = user32 advapi32 crypt32 shlwapi combase winhttp combase $(CXXABI_PE_LIBS) $(CXX_PE_LIBS) $(XML2_PE_LIBS) vcruntime140
+IMPORTS   = user32 advapi32 bcrypt crypt32 shlwapi combase winhttp combase $(CXXABI_PE_LIBS) $(CXX_PE_LIBS) $(XML2_PE_LIBS) vcruntime140
 EXTRAINCL = $(XML2_PE_CFLAGS)
 MODULE    = xgameruntime.dll
 UNIXLIB   = xgameruntime.so

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -244,6 +244,12 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
     {
         return IXNetworkingImpl_QueryInterface( x_networking, interfaceId, out );
     }
+    /* xuser.idl declares no coclass, so the interface id doubles as the runtime
+     * class id here - the same way XThreading is asked for. */
+    else if ( IsEqualGUID( runtimeClassId, &IID_IXUserImpl ) )
+    {
+        return IXUserImpl_QueryInterface( x_user, interfaceId, out );
+    }
     else if ( IsEqualGUID( runtimeClassId, &CLSID_XThreadingImpl ) )
     {
         /**
@@ -263,7 +269,8 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
     else if (IsEqualGUID( runtimeClassId, &CLSID_XStoreImpl ))
         return IXStoreImpl_QueryInterface( x_store, interfaceId, out );
     
-    FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );
+    FIXME( "%s not implemented, returning E_NOINTERFACE (caller %p).\n",
+           debugstr_guid( runtimeClassId ), __builtin_return_address( 0 ) );
     return E_NOTIMPL;
 }
 

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -268,6 +268,9 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
     }
     else if (IsEqualGUID( runtimeClassId, &CLSID_XStoreImpl ))
         return IXStoreImpl_QueryInterface( x_store, interfaceId, out );
+    /* xuser.idl gives the device coclass the same id as its first interface. */
+    else if ( IsEqualGUID( runtimeClassId, &IID_IXUserDeviceImpl ) )
+        return IXUserDeviceImpl2_QueryInterface( x_user_device, interfaceId, out );
     
     FIXME( "%s not implemented, returning E_NOINTERFACE (caller %p).\n",
            debugstr_guid( runtimeClassId ), __builtin_return_address( 0 ) );

--- a/dlls/xgameruntime/main.c
+++ b/dlls/xgameruntime/main.c
@@ -260,6 +260,8 @@ HRESULT WINAPI QueryApiImpl( const GUID *runtimeClassId, REFIID interfaceId, voi
         }
         return func( runtimeClassId, interfaceId, out );
     }
+    else if (IsEqualGUID( runtimeClassId, &CLSID_XStoreImpl ))
+        return IXStoreImpl_QueryInterface( x_store, interfaceId, out );
     
     FIXME( "%s not implemented, returning E_NOINTERFACE.\n", debugstr_guid( runtimeClassId ) );
     return E_NOTIMPL;

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -54,6 +54,7 @@
 #include <xuser.h>
 #include <xasync.h>
 #include <xasyncprovider.h>
+#include <xstore.h>
 
 #include "wine/unixlib.h"
 #include "wine/debug.h"
@@ -99,6 +100,7 @@ extern IXSystemImpl *x_system;
 extern IXSystemAnalyticsImpl *x_system_analytics;
 extern IXNetworkingImpl *x_networking;
 extern IXUserImpl *x_user;
+extern IXStoreImpl *x_store;
 
 #ifdef __cplusplus
 extern ABI::Xodus::IIPCLayer *xodus_ipclayer;

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -110,6 +110,7 @@ extern IXNetworkingImpl *x_networking;
 EXTERN_C const char *XodusProofKeyJwk( void );
 
 extern IXUserImpl *x_user;
+extern IXUserDeviceImpl2 *x_user_device;
 extern IXStoreImpl *x_store;
 
 #ifdef __cplusplus

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -89,10 +89,18 @@
 
 #define FAIL_FAST_IF_FAILED(hr)                                 do { HRESULT __hrRet = hr; if (FAILED(__hrRet)) { FAIL_FAST_MSG("%s 0x%#lx", #hr, __hrRet); }} while (0)
 
-#define POLL_BUFFER_SIZE 2048
+/* Must match the unix side: MSA token responses run to several kilobytes and a
+ * message larger than this buffer can never be completed. */
+#define POLL_BUFFER_SIZE 65536
 #define XODUS_SOCKET_SUFFIX "xodus.sock"
-#define IPC_REQUEST_TIMEOUT_MS 5000
-#define XODUS_INTEROP 0
+/* The MSA token exchange makes several round trips to Microsoft, so this has to
+ * cover a lot more than a local ping. */
+#define IPC_REQUEST_TIMEOUT_MS 60000
+#define XODUS_INTEROP 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 extern IXThreadingImpl *x_threading_impl;
 extern IXGameRuntimeFeatureImpl *x_game_runtime_feature;
@@ -138,6 +146,10 @@ extern unixlib_handle_t unixhandle;
 extern LPCSTR msaAppId;
 extern UINT32 titleId;
 extern BOOLEAN fullTrust;
+
+#ifdef __cplusplus
+}
+#endif
 
 typedef HRESULT (WINAPI *async_operation_callback)( IUnknown *invoker, PVOID param, PROPVARIANT *result );
 

--- a/dlls/xgameruntime/private.h
+++ b/dlls/xgameruntime/private.h
@@ -107,6 +107,8 @@ extern IXGameRuntimeFeatureImpl *x_game_runtime_feature;
 extern IXSystemImpl *x_system;
 extern IXSystemAnalyticsImpl *x_system_analytics;
 extern IXNetworkingImpl *x_networking;
+EXTERN_C const char *XodusProofKeyJwk( void );
+
 extern IXUserImpl *x_user;
 extern IXStoreImpl *x_store;
 

--- a/dlls/xgameruntime/xodusprovider.idl
+++ b/dlls/xgameruntime/xodusprovider.idl
@@ -110,6 +110,8 @@ namespace Xodus
     {
         HRESULT Ping( [out, retval] Windows.Foundation.IAsyncAction **operation );
         HRESULT MsaTokenRequest( [in] HSTRING clientId, [in] boolean allowUI, [in] boolean fullTrust, [out, retval] Windows.Foundation.IAsyncOperation<Xodus.IMsaTokenResponse *> **operation );
+        /* Same exchange, but for a specific Xbox Live relying party. */
+        HRESULT XstsTokenRequest( [in] HSTRING clientId, [in] HSTRING relyingParty, [out, retval] Windows.Foundation.IAsyncOperation<Xodus.IMsaTokenResponse *> **operation );
     }
 
     [
@@ -118,6 +120,7 @@ namespace Xodus
     interface IXodusXMLBuilder : IInspectable
     {
         HRESULT BuildMsaTokenRequestXml( [in] HSTRING clientId, [in] boolean allowUI, [in] boolean fullTrust, [out, retval] LPSTR *xml_string );
+        HRESULT BuildXstsTokenRequestXml( [in] HSTRING clientId, [in] HSTRING relyingParty, [out, retval] LPSTR *xml_string );
         HRESULT FromMsaTokenResponseXml( [in] LPCSTR xml_string, [out, retval] IMsaTokenResponse **response );
     }
 
@@ -129,6 +132,11 @@ namespace Xodus
     {
         [propget] HRESULT Token( [out, retval] HSTRING *out );
         [propget] HRESULT Expiry( [out, retval] Windows.Foundation.DateTime *out );
+        /* Xbox Live identity settled during the same exchange. Empty when the
+           service could not complete the XSTS step. */
+        [propget] HRESULT Xuid( [out, retval] HSTRING *out );
+        [propget] HRESULT Gamertag( [out, retval] HSTRING *out );
+        [propget] HRESULT XstsToken( [out, retval] HSTRING *out );
     }
 
     [

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -1259,6 +1259,7 @@ SOURCES = \
 	xnetworking.idl \
 	xpsobjectmodel.idl \
 	xpsobjectmodel_1.idl \
+	xstore.idl \
 	xsystem.idl \
 	xtaskqueue.h \
 	xuser.idl \

--- a/include/wine/unixlib.h
+++ b/include/wine/unixlib.h
@@ -278,12 +278,20 @@ NTSYSAPI int ntdll_wcsnicmp( const WCHAR *str1, const WCHAR *str2, int n );
 
 #else /* WINE_UNIX_LIB */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern unixlib_handle_t __wine_unixlib_handle;
 extern NTSTATUS (WINAPI *__wine_unix_call_dispatcher)( unixlib_handle_t, unsigned int, void * );
 extern NTSTATUS WINAPI __wine_init_unix_call(void);
 extern NTSTATUS WINAPI __wine_load_unix_lib( const UNICODE_STRING *name, unixlib_module_t *lib,
                                              unixlib_handle_t *handle );
 extern NTSTATUS WINAPI __wine_unload_unix_lib( unixlib_module_t lib );
+
+#ifdef __cplusplus
+}
+#endif
 
 #ifdef __arm64ec__
 NTSTATUS __wine_unix_call_arm64ec( unixlib_handle_t handle, unsigned int code, void *args );

--- a/include/xnetworking.idl
+++ b/include/xnetworking.idl
@@ -125,7 +125,7 @@ struct XNetworkingConnectivityHint
 struct XNetworkingSecurityInformation
 {
     UINT32 enabledHttpSecurityProtocolFlags;
-    SIZE_T thumbprintCount;
+    UINT32 thumbprintCount;
     XNetworkingThumbprint *thumbprints;
 };
 
@@ -141,7 +141,7 @@ struct XNetworkingTcpQueuedReceivedBufferUsageStatistics
 struct XNetworkingThumbprint
 {
     XNetworkingThumbprintType thumbprintType;
-    SIZE_T thumbprintBufferByteCount;
+    UINT32 thumbprintBufferByteCount;
     UINT8 *thumbprintBuffer;
 };
 

--- a/include/xstore.idl
+++ b/include/xstore.idl
@@ -1,0 +1,401 @@
+/*
+ * Copyright (C) the Wine project
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+import "unknwn.idl";
+import "xasync.h";
+import "xuser.idl";
+
+cpp_quote("#if 0")
+typedef UINT64 time_t;
+cpp_quote("#endif")
+
+cpp_quote("#ifdef __cplusplus")
+
+cpp_quote("enum class XStoreCanLicenseStatus : UINT32")
+cpp_quote("{                                         ")
+cpp_quote("    NotLicensableToUser,                  ")
+cpp_quote("    Licensable,                           ")
+cpp_quote("    LicenseActionNotApplicableToProduct,  ")
+cpp_quote("};                                        ")
+
+cpp_quote("enum class XStoreDurationUnit : UINT32")
+cpp_quote("{                                     ")
+cpp_quote("    Minute,                           ")
+cpp_quote("    Hour,                             ")
+cpp_quote("    Day,                              ")
+cpp_quote("    Week,                             ")
+cpp_quote("    Month,                            ")
+cpp_quote("    Year,                             ")
+cpp_quote("};                                    ")
+
+cpp_quote("enum class XStoreProductKind : UINT32")
+cpp_quote("{                                    ")
+cpp_quote("    None = 0x00,                     ")
+cpp_quote("    Consumable = 0x01,               ")
+cpp_quote("    Durable = 0x02,                  ")
+cpp_quote("    Game = 0x04,                     ")
+cpp_quote("    Pass = 0x08,                     ")
+cpp_quote("    UnmanagedConsumable = 0x10,      ")
+cpp_quote("};                                   ")
+
+cpp_quote("#elif defined(__WINESRC__)")
+
+typedef enum XStoreCanLicenseStatus
+{
+    XStoreCanLicenseStatus_NotLicensableToUser,
+    XStoreCanLicenseStatus_Licensable,
+    XStoreCanLicenseStatus_LicenseActionNotApplicableToProduct,
+} XStoreCanLicenseStatus;
+
+typedef enum XStoreDurationUnit
+{
+    XStoreDurationUnit_Minute,
+    XStoreDurationUnit_Hour,
+    XStoreDurationUnit_Day,
+    XStoreDurationUnit_Week,
+    XStoreDurationUnit_Month,
+    XStoreDurationUnit_Year,
+} XStoreDurationUnit;
+
+typedef enum XStoreProductKind
+{
+    XStoreProductKind_None = 0x00,
+    XStoreProductKind_Consumable = 0x01,
+    XStoreProductKind_Durable = 0x02,
+    XStoreProductKind_Game = 0x04,
+    XStoreProductKind_Pass = 0x08,
+    XStoreProductKind_UnmanagedConsumable = 0x10,
+} XStoreProductKind;
+
+cpp_quote("#endif")
+
+typedef void *XStoreContextHandle;
+typedef void *XStoreLicenseHandle;
+typedef void *XStoreProductQueryHandle;
+
+typedef struct XStoreAddonLicense XStoreAddonLicense;
+typedef struct XStoreAvailability XStoreAvailability;
+typedef struct XStoreCanAcquireLicenseResult XStoreCanAcquireLicenseResult;
+typedef struct XStoreCollectionData XStoreCollectionData;
+typedef struct XStoreConsumableResult XStoreConsumableResult;
+typedef struct XStoreGameLicense XStoreGameLicense;
+typedef struct XStoreImage XStoreImage;
+typedef struct XStorePackageUpdate XStorePackageUpdate;
+typedef struct XStorePrice XStorePrice;
+typedef struct XStoreProduct XStoreProduct;
+typedef struct XStoreRateAndReviewResult XStoreRateAndReviewResult;
+typedef struct XStoreSku XStoreSku;
+typedef struct XStoreSubscriptionInfo XStoreSubscriptionInfo;
+typedef struct XStoreVideo XStoreVideo;
+
+typedef void    __stdcall XStoreGameLicenseChangedCallback( void *context );
+typedef void    __stdcall XStorePackageLicenseLostCallback( void *context );
+typedef BOOLEAN __stdcall XStoreProductQueryCallback( const XStoreProduct *product, void *context );
+
+struct XStoreAddonLicense
+{
+    char skuStoreId[18];
+    char inAppOfferToken[64];
+    BOOLEAN isActive;
+    time_t expirationDate;
+};
+
+struct XStorePrice
+{
+    float basePrice;
+    float price;
+    float recurrencePrice;
+    const char *currencyCode;
+    char formattedBasePrice[16];
+    char formattedPrice[16];
+    char formattedRecurrencePrice[16];
+    BOOLEAN isOnSale;
+    time_t saleEndDate;
+};
+
+struct XStoreAvailability
+{
+    const char *availabilityId;
+    XStorePrice price;
+    time_t endDate;
+};
+
+struct XStoreCanAcquireLicenseResult
+{
+    char licensableSku[5];
+    XStoreCanLicenseStatus status;
+};
+
+struct XStoreCollectionData
+{
+    time_t acquiredDate;
+    time_t startDate;
+    time_t endDate;
+    BOOLEAN isTrial;
+    UINT32 trialTimeRemainingInSeconds;
+    UINT32 quantity;
+    const char *campaignId;
+    const char *developerOfferId;
+};
+
+struct XStoreConsumableResult
+{
+    UINT32 quantity;
+};
+
+struct XStoreGameLicense
+{
+    char skuStoreId[18];
+    BOOLEAN isActive;
+    BOOLEAN isTrialOwnedByThisUser;
+    BOOLEAN isDiscLicense;
+    BOOLEAN isTrial;
+    UINT32 trialTimeRemainingInSeconds;
+    char trialUniqueId[64];
+    time_t expirationDate;
+};
+
+struct XStoreImage
+{
+    const char *uri;
+    UINT32 height;
+    UINT32 width;
+    const char *caption;
+    const char *imagePurposeTag;
+};
+
+struct XStorePackageUpdate
+{
+    char packageIdentifier[33];
+    BOOLEAN isMandatory;
+};
+
+struct XStoreProduct
+{
+    const char *storeId;
+    const char *title;
+    const char *description;
+    const char *language;
+    const char *inAppOfferToken;
+    char *linkUri;
+    XStoreProductKind productKind;
+    XStorePrice price;
+    BOOLEAN hasDigitalDownload;
+    BOOLEAN isInUserCollection;
+    UINT32 keywordsCount;
+    const char **keywords;
+    UINT32 skusCount;
+    XStoreSku *skus;
+    UINT32 imagesCount;
+    XStoreImage *images;
+    UINT32 videosCount;
+    XStoreVideo *videos;
+};
+
+struct XStoreRateAndReviewResult
+{
+    BOOLEAN wasUpdated;
+};
+
+struct XStoreSubscriptionInfo
+{
+    BOOLEAN hasTrialPeriod;
+    XStoreDurationUnit trialPeriodUnit;
+    UINT32 trialPeriod;
+    XStoreDurationUnit billingPeriodUnit;
+    UINT32 billingPeriod;
+};
+
+struct XStoreSku
+{
+    const char *skuId;
+    const char *title;
+    const char *description;
+    const char *language;
+    XStorePrice price;
+    BOOLEAN isTrial;
+    BOOLEAN isInUserCollection;
+    XStoreCollectionData collectionData;
+    BOOLEAN isSubscription;
+    XStoreSubscriptionInfo subscriptionInfo;
+    UINT32 bundledSkusCount;
+    const char **bundledSkus;
+    UINT32 imagesCount;
+    XStoreImage *images;
+    UINT32 videosCount;
+    XStoreVideo *videos;
+    UINT32 availabilitiesCount;
+    XStoreAvailability *availabilities;
+};
+
+struct XStoreVideo
+{
+    const char *uri;
+    UINT32 height;
+    UINT32 width;
+    const char *caption;
+    const char *videoPurposeTag;
+    XStoreImage previewImage;
+};
+
+cpp_quote("#ifdef __WINESRC__")
+
+[
+    local,
+    object,
+    uuid(0dd112ac-7c24-448c-b92b-3960fb5bd30c)
+]
+interface IXStoreImpl : IUnknown
+{
+    HRESULT XStoreCreateContext( [in, optional] const XUserHandle user, [out] XStoreContextHandle *storeContextHandle );
+    void    XStoreCloseContextHandle( [in] XStoreContextHandle storeContextHandle );
+    HRESULT XStoreQueryAssociatedProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAssociatedProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in, string, size_is(storeIdsCount,)] const char **storeIds, [in] SIZE_T storeIdsCount, [in, optional, string, size_is(actionFiltersCount,)] const char **actionFilters, [in] SIZE_T actionFiltersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryEntitledProductsAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryEntitledProductsResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductForCurrentGameAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductForCurrentGameResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryProductForPackageAsync( [in] const XStoreContextHandle storeContextHandle, [in] XStoreProductKind productKinds, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryProductForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreEnumerateProductsQuery( [in] const XStoreProductQueryHandle productQueryHandle, [in, optional] void *context, [in] XStoreProductQueryCallback *callback );
+    BOOLEAN XStoreProductsQueryHasMorePages( [in] const XStoreProductQueryHandle productQueryHandle );
+    HRESULT XStoreProductsQueryNextPageAsync( [in] const XStoreProductQueryHandle productQueryHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreProductsQueryNextPageResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    void    XStoreCloseProductsQueryHandle( [in] XStoreProductQueryHandle productQueryHandle );
+    HRESULT XStoreAcquireLicenseForPackageAsync( [in] const XStoreProductQueryHandle productQueryHandle, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreAcquireLicenseForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreLicenseHandle *storeLicenseHandle );
+    BOOLEAN XStoreIsLicenseValid( [in] const XStoreLicenseHandle storeLicenseHandle );
+    void    XStoreCloseLicenseHandle( [in] XStoreLicenseHandle storeLicenseHandle );
+    HRESULT XStoreCanAcquireLicenseForStoreIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreCanAcquireLicenseForStoreIdResult( [in, out] XAsyncBlock *async, [out] XStoreCanAcquireLicenseResult *storeCanAcquireLicense );
+    HRESULT XStoreCanAcquireLicenseForPackageAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *packageIdentifier, [in, out] XAsyncBlock *async );
+    HRESULT XStoreCanAcquireLicenseForPackageResult( [in, out] XAsyncBlock *async, [out] XStoreCanAcquireLicenseResult *storeCanAcquireLicense );
+    HRESULT XStoreQueryGameLicenseAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameLicenseResult( [in, out] XAsyncBlock *async, [out] XStoreGameLicense *license );
+    HRESULT XStoreQueryAddOnLicensesAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAddOnLicensesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryAddOnLicensesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStoreAddonLicense addOnLicenses[*] );
+    HRESULT XStoreQueryConsumableBalanceRemainingAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryConsumableBalanceRemainingResult( [in, out] XAsyncBlock *async, [out] XStoreConsumableResult *consumableResult );
+    HRESULT XStoreReportConsumableFulfillmentAsync( [in, out] const XStoreContextHandle storeContextHandle, [in, string] const char *storeProductId, [in] UINT32 quantity, [in] GUID trackingId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreReportConsumableFulfillmentResult( [in, out] XAsyncBlock *async, [out] XStoreConsumableResult *consumableResult );
+    HRESULT XStoreGetUserCollectionsIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *serviceTicket, [in, string] const char *publisherUserId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreGetUserCollectionsIdResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreGetUserCollectionsIdResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT XStoreGetUserPurchaseIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *serviceTicket, [in, string] const char *publisherUserId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreGetUserPurchaseIdResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreGetUserPurchaseIdResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT XStoreQueryLicenseTokenAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(productIdsCount,)] const char **productIds, [in] SIZE_T productIdsCount, [in, string] const char *customDeveloperString, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryLicenseTokenResultSize( [in, out] XAsyncBlock *async, [out] SIZE_T *size );
+    HRESULT XStoreQueryLicenseTokenResult( [in, out] XAsyncBlock *async, [in] SIZE_T size, [out, string, size_is(size)] char *result );
+    HRESULT __PADDING__();
+    HRESULT __PADDING_2__();
+    HRESULT __PADDING_3__();
+    HRESULT XStoreShowPurchaseUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, optional, string] const char *name, [in, optional, string] const char *extendedJsonData, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowPurchaseUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRateAndReviewUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRateAndReviewUIResult( [in, out] XAsyncBlock *async, [out] XStoreRateAndReviewResult *result );
+    HRESULT XStoreShowRedeemTokenUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *token, [in, string, size_is(allowedStoreIdsCount,)] const char **allowedStoreIds, [in] SIZE_T allowedStoreIdsCount, [in] BOOLEAN disallowCsvRedemption, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowRedeemTokenUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryGameAndDlcPackageUpdatesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStorePackageUpdate packageUpdates[*] );
+    HRESULT XStoreDownloadPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadPackageUpdatesResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackageUpdatesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackageUpdatesResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackagesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string, size_is(storeIdsCount,)] const char **storeIds, [in] SIZE_T storeIdsCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreDownloadAndInstallPackagesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreDownloadAndInstallPackagesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, string, size_is(count,33)] char **packageIdentifiers );
+    HRESULT XStoreQueryPackageIdentifier( [in, string] const char *storeId, [in] SIZE_T size, [out, string, size_is(size)] char *packageIdentifier );
+    HRESULT XStoreRegisterGameLicenseChanged( [in] XStoreContextHandle storeContextHandle, [in] XTaskQueueHandle queue, [in, optional] void *context, [in] XStoreGameLicenseChangedCallback *callback, [out] XTaskQueueRegistrationToken *token );
+    BOOLEAN XStoreUnregisterGameLicenseChanged( [in] XStoreContextHandle storeContextHandle, [in] XTaskQueueRegistrationToken token, [in] BOOLEAN wait );
+    HRESULT XStoreRegisterPackageLicenseLost( [in] XStoreLicenseHandle licenseHandle, [in] XTaskQueueHandle queue, [in, optional] void *context, [in] XStorePackageLicenseLostCallback *callback, [out] XTaskQueueRegistrationToken *token );
+    BOOLEAN XStoreUnregisterPackageLicenseLost( [in] XStoreLicenseHandle licenseHandle, [in] XTaskQueueRegistrationToken token, [in] BOOLEAN wait );
+}
+
+[
+    local,
+    object,
+    uuid(60b09f4e-1b85-45b1-826c-169118e230e1)
+]
+interface IXStoreImpl2 : IXStoreImpl
+{
+    BOOLEAN XStoreIsAvailabilityPurchasable( [in] const XStoreAvailability availability );
+}
+
+[
+    local,
+    object,
+    uuid(2d42fea5-e71d-4b76-97cd-c50afbb3ae5d)
+]
+interface IXStoreImpl3 : IXStoreImpl2
+{
+    HRESULT XStoreAcquireLicenseForDurablesAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreAcquireLicenseForDurablesResult( [in, out] XAsyncBlock *async, [out] XStoreLicenseHandle *storeLicenseHandle );
+}
+
+[
+    local,
+    object,
+    uuid(de3dbdd4-0b37-4bdb-a10e-acf3a354d06a)
+]
+interface IXStoreImpl4 : IXStoreImpl3
+{
+    HRESULT XStoreShowAssociatedProductsUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in] XStoreProductKind productKinds, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowAssociatedProductsUIResult( [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowProductPageUIAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowProductPageUIResult( [in, out] XAsyncBlock *async );
+}
+
+[
+    local,
+    object,
+    uuid(5c48dedf-0b67-4492-a4b5-6829b8e796e1)
+]
+interface IXStoreImpl5 : IXStoreImpl4
+{
+    HRESULT XStoreQueryAssociatedProductsForStoreIdAsync( [in] const XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in] XStoreProductKind productKinds, [in] UINT32 maxItemsToRetrievePerPage, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryAssociatedProductsForStoreIdResult( [in, out] XAsyncBlock *async, [out] XStoreProductQueryHandle *productQueryHandle );
+    HRESULT XStoreQueryPackageUpdatesAsync( [in] XStoreContextHandle storeContextHandle, [in, string, size_is(packageIdentifiersCount,)] const char **packageIdentifiers, [in] SIZE_T packageIdentifiersCount, [in, out] XAsyncBlock *async );
+    HRESULT XStoreQueryPackageUpdatesResultCount( [in, out] XAsyncBlock *async, [out] UINT32 *count );
+    HRESULT XStoreQueryPackageUpdatesResult( [in, out] XAsyncBlock *async, [in] UINT32 count, [out, length_is(count)] XStorePackageUpdate packageUpdates[*] );
+}
+
+[
+    local,
+    object,
+    uuid(b09d803c-2414-4a05-82c6-66dfdc9e9a44)
+]
+interface IXStoreImpl6 : IXStoreImpl5
+{
+    HRESULT XStoreShowGiftingUIAsync( [in] XStoreContextHandle storeContextHandle, [in, string] const char *storeId, [in, optional, string] const char *name, [in, optional, string] const char *extendedJsonData, [in, out] XAsyncBlock *async );
+    HRESULT XStoreShowGiftingUIResult( [in, out] XAsyncBlock *async );
+}
+
+[
+    uuid(0dd112ac-7c24-448c-b92b-3960fb5bd30c)
+]
+coclass XStoreImpl
+{
+    [default] interface IXStoreImpl6;
+}
+
+cpp_quote("#endif")


### PR DESCRIPTION
Work from getting Game Pass titles to sign in under xodus. **RV There Yet? now signs in
and reaches gameplay**, Minecraft Bedrock is playable, and No Man's Sky's identity chain
is complete.

The series starts with the crash that took down every title and ends with the XUser gaps
found by tracing three of them.

## The crash

`XAsyncBegin` cleared `sizeof(internal)` **pointers** instead of bytes - 256 bytes on a
56-byte field, 224 of them past the end of the caller's `XAsyncBlock`. Upstream declares
`internal` as a byte array, which is why the element-wise loop reads as correct.

`XNetworkingSecurityInformation` also had `SIZE_T` where the GDK has `UINT32`, making the
struct 24 bytes instead of 16, and the security information query returned `E_NOTIMPL` -
with that answered, HTTPS works at all.

## The XUser gaps

Four of them, each found by tracing a title that stopped on its sign-in screen:

**`XUserCompare` returned `E_NOTIMPL`.** It is an ordering, not an `HRESULT`, so callers
read the failure code as "these two handles are never the same". No Man's Sky compared
users **14,947 times in one session** looking for a match that could not happen.

**`XUserGetTokenAndSignatureUtf16ResultSize` / `...Utf16Result` were stubs**, so a title
that asks for its token through the UTF-16 entry points got nothing. RV There Yet? does
exactly that and reported *"could not sign in"*; with the wide results filled in it signs
in and reaches gameplay.

**`XUserFindUserById` was a stub** although titles call it steadily - RV There Yet? asks
24 times during startup.

**The XUser device component was refused outright.** Titles that open on a "press to
begin" screen use it to work out which user an input device belongs to.

## Tokens for a title's own back end

Which token a title gets used to be decided by a single `strstr` for `"playfab"` in the
URL; everything else received a generic Xbox Live token, which publishers reject. The
request URL now travels to the service, which resolves it against the endpoint document,
and the answer is cached per host. The title id goes out with the token requests because
the document naming those relying parties is scoped to the title - and `TitleId` is
written in hex in MicrosoftGame.config, which we were reading as decimal.

The matching service-side change is xodus-gaming/xodus#154. Measured there:
No Man's Sky's auth server went from 400 to 200 with a JWT, and PlayFab from
`InvalidXboxLiveToken` to a SessionTicket.

## Also here

- `gameinput`: keep the mouse device when DirectInput is not ready yet, and acquire it
  lazily - without this Minecraft never sees the mouse
- `XStore` stub, plus a game license and an empty product query so titles stop waiting
- Real Xbox identity through xodus, request signing with an ECDSA P-256 proof key, and
  `IXUserGamertagImpl` (titles ask for it by IID and used to get `E_NOINTERFACE`)
- `mmdevapi`: honour `WINE_DISABLE_SPATIAL_AUDIO` - `ISpatialAudioClient` reports itself
  supported then hands out zero objects, and Wwise crashes on that; No Man's Sky ships Wwise
- `win32u`: answer `KMTQAITYPE_WDDM_2_7_CAPS`
- clang build fixes: `__wine_unix_call_dispatcher` and three windows.storage factories
  were declared without `extern "C"`, so C++ callers got mangled symbols

## Testing

Built with clang and run against Minecraft Bedrock 1.26.44, No Man's Sky 6.45 and
RV There Yet?. Testing used ChristopherHX's memfd loader on top of this branch, since
that is how xodus hands the decrypted image to Wine; nothing here depends on it.
