### PR TITLE
twinapi.appcore: RegisterAppStateChangeNotification should succeed

### DIFF
--- a/dlls/twinapi.appcore/main.c
+++ b/dlls/twinapi.appcore/main.c
@@ -30,13 +30,38 @@ ULONG WINAPI RegisterAppConstrainedChangeNotification( PAPPCONSTRAIN_CHANGE_ROUT
     return ERROR_CALL_NOT_IMPLEMENTED;
 }
 
+/* Opaque registration handle for RegisterAppStateChangeNotification().
+ *
+ * On real Windows this API always succeeds for a normal foreground desktop
+ * app and returns a valid PAPPSTATE_REGISTRATION handle (the callback is
+ * only ever invoked later, on suspend/resume, which never happens for an
+ * unpackaged desktop process). GDK/XGameRuntime app bring-up treats a
+ * non-ERROR_SUCCESS return from this call as fatal and aborts startup
+ * (calls XGameRuntimeUninitialize + exit(0)), so returning
+ * ERROR_CALL_NOT_IMPLEMENTED here - as the previous stub did - causes any
+ * GDK title to quietly exit right after this call. See appnotify.h /
+ * MSDN: "If this function succeeds, it returns ERROR_SUCCESS." */
+struct app_state_registration
+{
+    PAPPSTATE_CHANGE_ROUTINE routine;
+    void *context;
+};
+
 /***********************************************************************
  *           RegisterAppStateChangeNotification (twinapi.appcore.@)
  */
 ULONG WINAPI RegisterAppStateChangeNotification( PAPPSTATE_CHANGE_ROUTINE routine, void *context, PAPPSTATE_REGISTRATION *reg )
 {
-    FIXME( "routine %p, context %p, reg %p - stub.\n", routine, context, reg );
-    return ERROR_CALL_NOT_IMPLEMENTED;
+    struct app_state_registration *registration;
+
+    FIXME( "routine %p, context %p, reg %p - semi-stub, never notifies suspend/resume.\n", routine, context, reg );
+
+    if (!(registration = calloc( 1, sizeof(*registration) ))) return ERROR_OUTOFMEMORY;
+    registration->routine = routine;
+    registration->context = context;
+
+    *reg = (PAPPSTATE_REGISTRATION)registration;
+    return ERROR_SUCCESS;
 }
 
 /***********************************************************************
@@ -53,6 +78,7 @@ void WINAPI UnregisterAppConstrainedChangeNotification( PAPPCONSTRAIN_REGISTRATI
 void WINAPI UnregisterAppStateChangeNotification( PAPPSTATE_REGISTRATION reg )
 {
     FIXME( "reg %p - stub.\n", reg );
+    free( reg );
 }
 
 HRESULT WINAPI DllGetClassObject( REFCLSID clsid, REFIID riid, void **out )


### PR DESCRIPTION
## What's broken

`RegisterAppStateChangeNotification` is currently a plain stub returning `ERROR_CALL_NOT_IMPLEMENTED`. On real Windows this always succeeds for a normal foreground desktop app and hands back a valid `PAPPSTATE_REGISTRATION` handle — the registered callback is only ever invoked later, on suspend/resume, which never happens for an unpackaged desktop process anyway. See `appnotify.h` / MSDN: *"If this function succeeds, it returns ERROR_SUCCESS."*

## Why this specifically breaks GDK titles

XGameRuntime's own app bring-up sequence calls this during startup and treats any non-`ERROR_SUCCESS` return as fatal — it calls `XGameRuntimeUninitialize()` and exits the process. So the practical effect of the current stub is that **every GDK title quietly exits right after this call, before any window is ever created**, with nothing in the log pointing at why beyond this one function's own `FIXME` line.

## How I found it (and why I'm sending this here)

I hit and fixed this independently while chasing exactly this "clean `ExitProcess(0)`, no window, no error" symptom in my own downstream fork of this ecosystem (`73chn1c/xgameruntime` + a Wine fork carrying the same `twinapi.appcore` change). It was only afterward, doing a broader comparison across the GDK-on-Wine ecosystem, that I noticed this repo still has the original stub.

The fix is small, safe, and already validated across **five real titles spanning four different engines** in my own build: Balatro (LÖVE2D), two Unity titles, an Unreal Engine 4 title, and a self-contained CoreCLR/MonoGame title — every one of them was previously exiting silently at this exact call, and every one proceeds past it correctly with this fix in place. Given that, it seemed worth sending back rather than letting our two implementations quietly diverge on something this fundamental.

## What the fix does

- `RegisterAppStateChangeNotification` allocates a small heap-backed registration record (just the callback pointer + context) and returns it as the handle, instead of never producing one.
- `UnregisterAppStateChangeNotification` is updated to match — it was a no-op stub before, so registrations from a fixed `Register` would otherwise leak for the process's lifetime. It now frees what `Register` allocated.
- The callback itself is still never actually invoked (there's no real suspend/resume/constrained-state machinery here to drive it from), which is why the `FIXME` stays in place as "semi-stub" rather than being removed outright — this makes the handshake succeed, it doesn't implement the full notification behavior.

## Testing

Not build-tested against this specific repo in this session — I don't have a WineGDK build environment set up here. This is a direct, character-for-character port of the fix already built and live-tested across those five titles in my own fork, so I'm confident in the correctness of the code itself, but a fresh build/CI pass on this repo is still worth doing before merge.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
